### PR TITLE
Fix duplicate getAvatar declaration

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -78,8 +78,6 @@ const ChatConversationPage: React.FC = () => {
     setTimeout(() => inputRef.current?.focus(), 0);
   };
 
-  const getAvatar = (id: string) => avatars.find((a) => a.id === id) || avatars[0];
-
   return (
     <div className="chat-container" style={{ paddingBottom: 80, position: 'relative' }}>
       <Link to="/chat" style={{ display: 'block', marginBottom: 8 }}>


### PR DESCRIPTION
## Summary
- remove duplicate getAvatar definition in ChatConversationPage

## Testing
- `npm run build`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6841fb5aa4848332914a94df8e55a325