### PR TITLE
Add chat inbox header with tabs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -196,6 +196,44 @@
   font-weight: bold;
 }
 
+.inbox-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  border-bottom: 1px solid #ccc;
+  background: #fff;
+  position: sticky;
+  top: 0;
+  z-index: 3;
+}
+
+.settings-icon {
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.tabs {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.tabs button {
+  flex: 1;
+  padding: 8px 0;
+  background: #f5f5f5;
+  border: none;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tabs button.active {
+  font-weight: bold;
+  border-bottom-color: #000;
+  background: #fff;
+}
+
 
 @keyframes App-logo-spin {
   from {

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { ChatList } from 'react-chat-elements';
@@ -6,7 +6,7 @@ import 'react-chat-elements/dist/main.css';
 
 const ChatInboxPage: React.FC = () => {
   const navigate = useNavigate();
-  const chats = [
+  const executedChats = [
     {
       id: 'kursat',
 
@@ -90,11 +90,53 @@ const ChatInboxPage: React.FC = () => {
     },
   ];
 
+  const scheduledChats = executedChats.slice(0, 3);
+  const draftChats = executedChats.slice(3);
+
+  const [activeTab, setActiveTab] = useState<'executed' | 'scheduled' | 'draft'>('executed');
+
+  const getChats = () => {
+    switch (activeTab) {
+      case 'scheduled':
+        return scheduledChats;
+      case 'draft':
+        return draftChats;
+      default:
+        return executedChats;
+    }
+  };
+
   return (
     <div className="chat-container">
-     <ChatList
+      <div className="inbox-header">
+        <h2>Chats</h2>
+        <span className="settings-icon" role="img" aria-label="settings">
+          ⚙️
+        </span>
+      </div>
+      <div className="tabs">
+        <button
+          className={activeTab === 'executed' ? 'active' : ''}
+          onClick={() => setActiveTab('executed')}
+        >
+          Executed
+        </button>
+        <button
+          className={activeTab === 'scheduled' ? 'active' : ''}
+          onClick={() => setActiveTab('scheduled')}
+        >
+          Scheduled
+        </button>
+        <button
+          className={activeTab === 'draft' ? 'active' : ''}
+          onClick={() => setActiveTab('draft')}
+        >
+          Draft
+        </button>
+      </div>
+      <ChatList
         className="chat-list"
-        dataSource={chats}
+        dataSource={getChats()}
         onClick={(item: any) => {
           navigate(`/chat/${(item as any).id}`);
         }}


### PR DESCRIPTION
## Summary
- add Executed/Scheduled/Draft tabs to `/chat`
- show a header with a settings icon for the chat inbox
- style new header and tabs

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420e321b688332bc0e973904f19806