### PR TITLE
Fix ChatInboxPage lint

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -153,16 +153,6 @@ const ChatInboxPage: React.FC = () => {
     };
   }, []);
 
-  const getChats = () => {
-    switch (tabIndex) {
-      case 1:
-        return scheduledChats;
-      case 2:
-        return draftChats;
-      default:
-        return executedChats;
-    }
-  };
 
   return (
     <div className="chat-container" style={{ height: viewportHeight }}>


### PR DESCRIPTION
## Summary
- remove unused `getChats` helper to satisfy eslint

## Testing
- `npm run build`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684217aed11c8332b52f155de4bfe4f6