### PR TITLE
Remove unused variable causing lint failure

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -36,7 +36,6 @@ interface Message {
   replyTo?: number;
 }
 
-const nowIso = new Date().toISOString();
 const initialMessages: Record<string, Message[]> = {
   kursat: [{ id: 1, from: 'kursat', text: "Why don't we go to the mall this weekend ?", delay: 0 }],
   emre: [{ id: 1, from: 'emre', text: 'Send me our photos.', delay: 0 }],


### PR DESCRIPTION
## Summary
- remove unused `nowIso` variable from `ChatConversationPage`

## Testing
- `npm run build` *(fails: `react-scripts: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684293dab22883329dbca30d41a0f1ba