### PR TITLE
Enhance input focus behavior

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -163,6 +163,11 @@
   padding: 8px;
   background: #fff;
   border-top: 1px solid #ccc;
+  transition: all 0.3s;
+}
+
+.message-input-container.focused .MuiIconButton-root:not(.send-button) {
+  display: none;
 }
 
 .message-input-container textarea {
@@ -174,6 +179,11 @@
   font-size: 14px;
   background: #f9f9f9;
   line-height: 1.4;
+  transition: width 0.3s;
+}
+
+.message-input-container.focused textarea {
+  width: 100%;
 }
 
 .selected-avatar {
@@ -203,8 +213,19 @@
   cursor: pointer;
 }
 
+.reply-preview-wrapper {
+  position: fixed;
+  bottom: 60px;
+  left: 0;
+  right: 0;
+  max-width: 480px;
+  margin: 0 auto;
+  padding: 8px;
+  z-index: 5;
+}
+
 .reply-preview {
-  font-size: 12px;
+  font-size: 16px;
   background: #f0f0f0;
   padding: 4px;
   border-left: 4px solid #ccc;
@@ -218,6 +239,7 @@
   margin-left: 8px;
   cursor: pointer;
   font-weight: bold;
+  font-size: 20px;
 }
 
 .chat-header {

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -83,6 +83,7 @@ const ChatConversationPage: React.FC = () => {
   const conversationIdRef = useRef<string>(`conv-${Math.random().toString(36).slice(2, 10)}`);
   const skipScrollRef = useRef(false);
   const [jsonOpen, setJsonOpen] = useState(false);
+  const [inputFocused, setInputFocused] = useState(false);
 
   const scrollToMessage = (msgId: number | undefined) => {
     if (!msgId) return;
@@ -142,7 +143,12 @@ const ChatConversationPage: React.FC = () => {
     const targetId = replyTo?.id ?? messages[messages.length - 1]?.id;
     scrollToMessage(targetId);
     setTimeout(scrollToBottomIfNeeded, 100);
+    setInputFocused(true);
 
+  };
+
+  const handleBlur = () => {
+    setInputFocused(false);
   };
 
   const getAvatar = (id: string) => avatars.find((a) => a.id === id) || avatars[0];
@@ -516,7 +522,22 @@ const ChatConversationPage: React.FC = () => {
           );
         })}
       </div>
-      <div className="message-input-container">
+      {replyTo && (
+        <div className="reply-preview-wrapper">
+          <div className="reply-preview">
+            <span>Replying to: {replyTo.text}</span>
+            <span
+              className="cancel-reply"
+              role="button"
+              aria-label="cancel reply"
+              onClick={() => setReplyTo(null)}
+            >
+              ×
+            </span>
+          </div>
+        </div>
+      )}
+      <div className={`message-input-container ${inputFocused ? 'focused' : ''}`}>
         <div style={{ position: 'relative' }}>
           <img
             src={selectedAvatar.avatar}
@@ -540,20 +561,7 @@ const ChatConversationPage: React.FC = () => {
             </div>
           )}
         </div>
-       <div style={{ flex: 1 }}>
-          {replyTo && (
-            <div className="reply-preview">
-              <span>Replying to: {replyTo.text}</span>
-              <span
-                className="cancel-reply"
-                role="button"
-                aria-label="cancel reply"
-                onClick={() => setReplyTo(null)}
-              >
-                ×
-              </span>
-            </div>
-          )}
+      <div style={{ flex: 1 }}>
           {editingId !== null && (
             <div className="reply-preview">Editing message</div>
           )}
@@ -575,6 +583,7 @@ const ChatConversationPage: React.FC = () => {
               }
             }}
             onFocus={handleFocus}
+            onBlur={handleBlur}
             placeholder="Type here..."
             style={{ resize: 'none', overflow: 'hidden' }}
           />
@@ -599,6 +608,7 @@ const ChatConversationPage: React.FC = () => {
         </IconButton>
 
         <IconButton
+          className="send-button"
           onMouseDown={(e) => e.preventDefault()}
           onClick={handleSend}
           color="primary"


### PR DESCRIPTION
## Summary
- expand `message-input-container` on focus
- hide extra icon buttons when typing
- position reply preview above the input and enlarge it

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68430fd01170833281305b8ae5dbf6d8