### PR TITLE
Add chat SpeedDial with group and prompt dialogs

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -10,6 +10,14 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import CircularProgress from '@mui/material/CircularProgress';
+import SpeedDial from '@mui/material/SpeedDial';
+import SpeedDialIcon from '@mui/material/SpeedDialIcon';
+import SpeedDialAction from '@mui/material/SpeedDialAction';
+import GroupAddIcon from '@mui/icons-material/GroupAdd';
+import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest';
+import TextField from '@mui/material/TextField';
+import Checkbox from '@mui/material/Checkbox';
+import FormControlLabel from '@mui/material/FormControlLabel';
 
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
@@ -59,7 +67,11 @@ const initialMessages: Record<string, Message[]> = {
   abdurrahman: [{ id: 1, from: 'abdurrahman', text: 'Where is the presentation file ?', delay: 0 }],
   ahmet: [{ id: 1, from: 'ahmet', text: "Let's join the daily meeting.", delay: 0 }],
 
+};
 
+const groupCategories: Record<string, string[]> = {
+  Sports: ['Football Fans', 'Basketball Lovers'],
+  Movies: ['Sci-Fi Lovers', 'Comedy Club'],
 };
 
 const ChatConversationPage: React.FC = () => {
@@ -87,6 +99,26 @@ const ChatConversationPage: React.FC = () => {
   const [jsonOpen, setJsonOpen] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [speedDialOpen, setSpeedDialOpen] = useState(false);
+  const [groupDialogOpen, setGroupDialogOpen] = useState(false);
+  const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
+  const [promptDialogOpen, setPromptDialogOpen] = useState(false);
+  const [systemPrompt, setSystemPrompt] = useState({
+    displayName: '',
+    occupation: '',
+    assistantTraits: '',
+    extraContext: '',
+  });
+
+  const handleToggleGroup = (group: string) => {
+    setSelectedGroups((prev) =>
+      prev.includes(group) ? prev.filter((g) => g !== group) : [...prev, group]
+    );
+  };
+
+  const handlePromptChange = (field: keyof typeof systemPrompt, value: string) => {
+    setSystemPrompt((prev) => ({ ...prev, [field]: value }));
+  };
 
   const gestureRef = useRef({
     startX: 0,
@@ -665,6 +697,97 @@ const handleInputChange = (
         </DialogContent>
         <DialogActions>
           <Button onClick={() => setJsonOpen(false)}>Close</Button>
+        </DialogActions>
+      </Dialog>
+
+      <SpeedDial
+        ariaLabel="chat actions"
+        open={speedDialOpen}
+        onOpen={() => setSpeedDialOpen(true)}
+        onClose={() => setSpeedDialOpen(false)}
+        sx={{ position: 'absolute', bottom: 16, right: 16 }}
+      >
+        <SpeedDialAction
+          icon={<GroupAddIcon />}
+          tooltipTitle="Add Group"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            setGroupDialogOpen(true);
+          }}
+        />
+        <SpeedDialAction
+          icon={<SettingsSuggestIcon />}
+          tooltipTitle="System Prompt"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            setPromptDialogOpen(true);
+          }}
+        />
+      </SpeedDial>
+
+      <Dialog open={groupDialogOpen} onClose={() => setGroupDialogOpen(false)} fullWidth>
+        <DialogTitle>Select Groups</DialogTitle>
+        <DialogContent dividers>
+          {Object.entries(groupCategories).map(([cat, groups]) => (
+            <div key={cat} style={{ marginBottom: 8 }}>
+              <div style={{ fontWeight: 'bold' }}>{cat}</div>
+              {groups.map((g) => (
+                <FormControlLabel
+                  key={g}
+                  control={
+                    <Checkbox
+                      checked={selectedGroups.includes(g)}
+                      onChange={() => handleToggleGroup(g)}
+                    />
+                  }
+                  label={g}
+                />
+              ))}
+            </div>
+          ))}
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setGroupDialogOpen(false)}>Done</Button>
+        </DialogActions>
+      </Dialog>
+
+      <Dialog
+        open={promptDialogOpen}
+        onClose={() => setPromptDialogOpen(false)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>System Prompt</DialogTitle>
+        <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          <TextField
+            label="Nickname"
+            value={systemPrompt.displayName}
+            onChange={(e) => handlePromptChange('displayName', e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="What do you do?"
+            value={systemPrompt.occupation}
+            onChange={(e) => handlePromptChange('occupation', e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="AI traits"
+            value={systemPrompt.assistantTraits}
+            onChange={(e) => handlePromptChange('assistantTraits', e.target.value)}
+            fullWidth
+          />
+          <TextField
+            label="Anything else?"
+            value={systemPrompt.extraContext}
+            onChange={(e) => handlePromptChange('extraContext', e.target.value)}
+            fullWidth
+            multiline
+            rows={3}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setPromptDialogOpen(false)}>Close</Button>
         </DialogActions>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- add SpeedDial with group and system prompt actions
- allow group selection from categories
- configure AI system prompt values

## Testing
- `npm ci`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843859ea4088332aa54eba51f5a9c80