### PR TITLE
Add swipe navigation for chat conversations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -186,6 +186,32 @@
   margin-left: 4px;
 }
 
+.chat-messages.animate-left {
+  animation: slideLeft 0.35s forwards;
+}
+
+.chat-messages.animate-right {
+  animation: slideRight 0.35s forwards;
+}
+
+@keyframes slideLeft {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 .selected-avatar {
   width: 40px;
   height: 40px;
@@ -254,6 +280,27 @@
   color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 2;
+}
+
+.conversation-nav {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.conversation-nav button {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: none;
+  background: #eee;
+  cursor: pointer;
+}
+
+.conversation-nav button.active {
+  background: #0088cc;
+  color: #fff;
 }
 
 .back-icon {

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -50,6 +50,12 @@ interface Message {
   replyTo?: number;
 }
 
+interface Conversation {
+  id: string;
+  startDateTime: Date;
+  messages: Message[];
+}
+
 const initialMessages: Record<string, Message[]> = {
   kursat: [{ id: 1, from: 'kursat', text: "Why don't we go to the mall this weekend ?", delay: 0 }],
   emre: [{ id: 1, from: 'emre', text: 'Send me our photos.', delay: 0 }],
@@ -65,11 +71,22 @@ const initialMessages: Record<string, Message[]> = {
 
 const ChatConversationPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
-  const [messages, setMessages] = useState<Message[]>(initialMessages[id ?? ''] || []);
+
+  const initialStart = new Date();
+  const [conversations, setConversations] = useState<Conversation[]>([
+    {
+      id: `conv-${Math.random().toString(36).slice(2, 10)}`,
+      startDateTime: initialStart,
+      messages: initialMessages[id ?? ''] || [],
+    },
+  ]);
+  const [conversationIndex, setConversationIndex] = useState(0);
+  const [transitionDir, setTransitionDir] = useState<'left' | 'right' | null>(null);
+
   const [text, setText] = useState('');
   const [selectedAvatar, setSelectedAvatar] = useState<Avatar>(avatars[0]);
   const [showAvatars, setShowAvatars] = useState(false);
- const [replyTo, setReplyTo] = useState<Message | null>(null);
+  const [replyTo, setReplyTo] = useState<Message | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [menuId, setMenuId] = useState<number | null>(null);
   const [swipeId, setSwipeId] = useState<number | null>(null);
@@ -79,15 +96,36 @@ const ChatConversationPage: React.FC = () => {
   const [delayMenuId, setDelayMenuId] = useState<number | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
-  const initialStart = new Date();
-  const [startDateTime, setStartDateTime] = useState<Date>(initialStart);
-  const conversationStartRef = useRef<string>(initialStart.toISOString());
 
-  const conversationIdRef = useRef<string>(`conv-${Math.random().toString(36).slice(2, 10)}`);
   const skipScrollRef = useRef(false);
   const [jsonOpen, setJsonOpen] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [generating, setGenerating] = useState(false);
+
+  const pageGestureRef = useRef({ startX: 0, startY: 0, dragging: false });
+
+  const currentConversation = conversations[conversationIndex];
+  const messages = currentConversation.messages;
+  const startDateTime = currentConversation.startDateTime;
+
+  const updateMessages = (updater: (prev: Message[]) => Message[]) => {
+    setConversations((prev) => {
+      const next = [...prev];
+      next[conversationIndex] = {
+        ...next[conversationIndex],
+        messages: updater(next[conversationIndex].messages),
+      };
+      return next;
+    });
+  };
+
+  const updateStartDateTime = (dt: Date) => {
+    setConversations((prev) => {
+      const next = [...prev];
+      next[conversationIndex] = { ...next[conversationIndex], startDateTime: dt };
+      return next;
+    });
+  };
 
   const gestureRef = useRef({
     startX: 0,
@@ -117,7 +155,7 @@ const ChatConversationPage: React.FC = () => {
   };
 
   const handleDelete = (id: number) => {
-    setMessages((prev) => prev.filter((m) => m.id !== id));
+    updateMessages((prev) => prev.filter((m) => m.id !== id));
     setMenuId(null);
     setMenuPosition(null);
   };
@@ -133,22 +171,22 @@ const ChatConversationPage: React.FC = () => {
 
 const handleSend = () => {
   if (!text.trim()) return;
-  setMessages((prev) => {
-      if (editingId !== null) {
-        return prev.map((m) => (m.id === editingId ? { ...m, text } : m));
-      }
-      const newId = prev.length ? prev[prev.length - 1].id + 1 : 1;
-      return [
-        ...prev,
-        {
-          id: newId,
-          from: selectedAvatar.id,
-          text,
-          delay: 0,
-          replyTo: replyTo?.id,
-        },
-      ];
-    });
+  updateMessages((prev) => {
+    if (editingId !== null) {
+      return prev.map((m) => (m.id === editingId ? { ...m, text } : m));
+    }
+    const newId = prev.length ? prev[prev.length - 1].id + 1 : 1;
+    return [
+      ...prev,
+      {
+        id: newId,
+        from: selectedAvatar.id,
+        text,
+        delay: 0,
+        replyTo: replyTo?.id,
+      },
+    ];
+  });
     setText('');
     setEditingId(null);
     setReplyTo(null);
@@ -185,7 +223,7 @@ const handleSend = () => {
 
   const handleAddDelay = (id: number, minutes: number) => {
     skipScrollRef.current = true;
-    setMessages((prev) =>
+    updateMessages((prev) =>
       prev.map((m) => (m.id === id ? { ...m, delay: m.delay + minutes } : m))
     );
     setDelayMenuId(null);
@@ -193,13 +231,13 @@ const handleSend = () => {
 
   const handleResetDelay = (id: number) => {
     skipScrollRef.current = true;
-    setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, delay: 0 } : m)));
+    updateMessages((prev) => prev.map((m) => (m.id === id ? { ...m, delay: 0 } : m)));
     setDelayMenuId(null);
   };
 
   const handleGenerateAI = () => {
     setGenerating(true);
-    setMessages((prev) => {
+    updateMessages((prev) => {
       const startId = prev.length ? prev[prev.length - 1].id + 1 : 1;
       const generated: Message[] = [];
       for (let i = 0; i < 10; i++) {
@@ -222,45 +260,55 @@ const handleSend = () => {
     for (let i = 1; i <= index; i++) {
       total += messages[i].delay;
     }
-    return new Date(
-      new Date(conversationStartRef.current).getTime() + total * 60000
-    ).toISOString();
+    return new Date(startDateTime.getTime() + total * 60000).toISOString();
   };
 
   const generateJSON = () => {
-    let cumulative = 0;
-    const start = new Date(conversationStartRef.current).getTime();
-    const msgs = messages.map((m, idx) => {
-      if (idx > 0) {
-        cumulative += m.delay;
-      }
-      const timestamp = new Date(start + cumulative * 60000).toISOString();
-      const relative = idx === 0 ? 0 : m.delay * 60;
+    const conversationsJson = conversations.map((conv) => {
+      let cumulative = 0;
+      const start = conv.startDateTime.getTime();
+      const msgs = conv.messages.map((m, idx) => {
+        if (idx > 0) {
+          cumulative += m.delay;
+        }
+        const timestamp = new Date(start + cumulative * 60000).toISOString();
+        const relative = idx === 0 ? 0 : m.delay * 60;
+
+        return {
+          message_id: `m-${m.id}`,
+          sender_id: m.from,
+          sender_name: m.from,
+          message_content: m.text,
+          message_type: 'text',
+          timestamp,
+          relative_time: relative,
+          status: 'pending',
+          metadata: {
+            language: 'en',
+          },
+        };
+      });
 
       return {
-        message_id: `m-${m.id}`,
-        sender_id: m.from,
-        sender_name: m.from,
-        message_content: m.text,
-        message_type: 'text',
-        timestamp,
-
-        relative_time: relative,
-        status: 'pending',
-        metadata: {
-          language: 'en',
-        },
+        conversation_id: conv.id,
+        start_time: conv.startDateTime.toISOString(),
+        initiated_by: conv.messages[0]?.from || selectedAvatar.id,
+        topic: '',
+        conversation_metadata: { active: true, tags: [] },
+        messages: msgs,
       };
     });
 
-    const members = Array.from(new Set(messages.map((m) => m.from))).map((u) => ({
+    const memberSet = new Set(
+      conversations.flatMap((c) => c.messages.map((m) => m.from))
+    );
+    const members = Array.from(memberSet).map((u) => ({
       telegram_user_id: u,
       telegram_user_name: u,
       role: 'member',
       status: 'active',
-      joined_at: conversationStartRef.current,
+      joined_at: conversations[0].startDateTime.toISOString(),
     }));
-
 
     return {
       system_metadata: {
@@ -279,17 +327,7 @@ const handleSend = () => {
           created_by: 123456789,
           group_description: '',
           members,
-
-          conversations: [
-            {
-              conversation_id: conversationIdRef.current,
-              start_time: conversationStartRef.current,
-              initiated_by: selectedAvatar.id,
-              topic: '',
-              conversation_metadata: { active: true, tags: [] },
-              messages: msgs,
-            },
-          ],
+          conversations: conversationsJson,
         },
       ],
       ai_users: [],
@@ -316,7 +354,14 @@ const handleInputChange = (
     } else {
       scrollToBottomIfNeeded();
     }
-  }, [messages]);
+  }, [conversations, conversationIndex]);
+
+  useEffect(() => {
+    if (transitionDir) {
+      const t = setTimeout(() => setTransitionDir(null), 350);
+      return () => clearTimeout(t);
+    }
+  }, [transitionDir]);
 
   useEffect(() => {
     if (replyTo) {
@@ -325,8 +370,9 @@ const handleInputChange = (
   }, [replyTo]);
 
   useEffect(() => {
-    conversationStartRef.current = startDateTime.toISOString();
-  }, [startDateTime]);
+    scrollToBottomIfNeeded();
+  }, [conversationIndex]);
+
 
   useEffect(() => {
     const handleResize = () => {
@@ -352,6 +398,74 @@ const handleInputChange = (
         setMenuId(null);
         setMenuPosition(null);
       }}
+      onTouchStart={(e) => {
+        const g = pageGestureRef.current;
+        g.startX = e.touches[0].clientX;
+        g.startY = e.touches[0].clientY;
+        g.dragging = true;
+      }}
+      onTouchEnd={(e) => {
+        const g = pageGestureRef.current;
+        if (!g.dragging) return;
+        const dx = e.changedTouches[0].clientX - g.startX;
+        const dy = e.changedTouches[0].clientY - g.startY;
+        g.dragging = false;
+        if (Math.abs(dx) > 50 && Math.abs(dy) < 30) {
+          if (dx < 0) {
+            if (conversationIndex === conversations.length - 1) {
+              setConversations((prev) => [
+                ...prev,
+                {
+                  id: `conv-${Math.random().toString(36).slice(2, 10)}`,
+                  startDateTime: new Date(),
+                  messages: [],
+                },
+              ]);
+              setConversationIndex((i) => i + 1);
+            } else {
+              setConversationIndex((i) => i + 1);
+            }
+            setTransitionDir('left');
+          } else if (dx > 0 && conversationIndex > 0) {
+            setConversationIndex((i) => i - 1);
+            setTransitionDir('right');
+          }
+        }
+      }}
+      onMouseDown={(e) => {
+        const g = pageGestureRef.current;
+        g.startX = e.clientX;
+        g.startY = e.clientY;
+        g.dragging = true;
+      }}
+      onMouseUp={(e) => {
+        const g = pageGestureRef.current;
+        if (!g.dragging) return;
+        const dx = e.clientX - g.startX;
+        const dy = e.clientY - g.startY;
+        g.dragging = false;
+        if (Math.abs(dx) > 50 && Math.abs(dy) < 30) {
+          if (dx < 0) {
+            if (conversationIndex === conversations.length - 1) {
+              setConversations((prev) => [
+                ...prev,
+                {
+                  id: `conv-${Math.random().toString(36).slice(2, 10)}`,
+                  startDateTime: new Date(),
+                  messages: [],
+                },
+              ]);
+              setConversationIndex((i) => i + 1);
+            } else {
+              setConversationIndex((i) => i + 1);
+            }
+            setTransitionDir('left');
+          } else if (dx > 0 && conversationIndex > 0) {
+            setConversationIndex((i) => i - 1);
+            setTransitionDir('right');
+          }
+        }
+      }}
     >
       <div className="chat-header">
         <Link to="/chat" className="back-icon">←</Link>
@@ -362,6 +476,22 @@ const handleInputChange = (
         />
         <span className="header-name">{id}</span>
       </div>
+      <div className="conversation-nav">
+        {conversations.map((c, idx) => (
+          <button
+            key={c.id}
+            className={idx === conversationIndex ? 'active' : ''}
+            onClick={() => {
+              if (idx !== conversationIndex) {
+                setTransitionDir(idx > conversationIndex ? 'left' : 'right');
+                setConversationIndex(idx);
+              }
+            }}
+          >
+            {idx + 1}
+          </button>
+        ))}
+      </div>
       <div className="instruction-text">
         You are creating messages. The AI will execute these messages.
       </div>
@@ -370,7 +500,7 @@ const handleInputChange = (
         style={{ display: 'flex', gap: 4, marginBottom: 8, alignItems: 'center' }}
       >
         <span style={{ fontSize: 14 }}>Executed at</span>
-        <DateTimePicker onChange={(d) => d && setStartDateTime(d)} value={startDateTime} />
+        <DateTimePicker onChange={(d) => d && updateStartDateTime(d)} value={startDateTime} />
       </div>
       <Button
         className="generate-btn"
@@ -388,7 +518,12 @@ const handleInputChange = (
           </>
         )}
       </Button>
-      <div className="chat-messages" ref={messagesRef}>
+      <div
+        className={`chat-messages ${
+          transitionDir ? `animate-${transitionDir}` : ''
+        }`}
+        ref={messagesRef}
+      >
         {messages.map((msg, idx) => {
           const av = getAvatar(msg.from);
           const me = msg.from === selectedAvatar.id;


### PR DESCRIPTION
## Summary
- support multiple conversations per chat with separate start time
- enable swiping left/right on chat page to navigate between conversations and include nav buttons in header
- animate page transitions like turning a page
- generate JSON containing all conversations

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446b3c0b3c83329529007c7de3951a