### PR TITLE
Add pagination with draggable swipe

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -186,6 +186,32 @@
   margin-left: 4px;
 }
 
+.chat-messages.animate-left {
+  animation: slideLeft 0.35s forwards;
+}
+
+.chat-messages.animate-right {
+  animation: slideRight 0.35s forwards;
+}
+
+@keyframes slideLeft {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideRight {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
 .selected-avatar {
   width: 40px;
   height: 40px;
@@ -255,6 +281,14 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 2;
 }
+
+.conversation-nav {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
 
 .back-icon {
   text-decoration: none;


### PR DESCRIPTION
## Summary
- make conversations follow finger drag when swiping
- replace header nav with Material UI pagination
- show add button when swiping/scrolling past the last conversation

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `npx tsc -p tsconfig.json` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68446b3c0b3c83329529007c7de3951a