### PR TITLE
Fix build by guarding item.page and adding TS declarations

### DIFF
--- a/src/mui-icons.d.ts
+++ b/src/mui-icons.d.ts
@@ -1,0 +1,8 @@
+declare module '@mui/icons-material/Send';
+declare module '@mui/icons-material/Timer';
+declare module '@mui/icons-material/SmartToy';
+declare module '@mui/icons-material/Reply';
+declare module '@mui/icons-material/Settings';
+declare module '@mui/icons-material/GroupAdd';
+declare module '@mui/icons-material/SettingsSuggest';
+declare module '@mui/icons-material/InfoOutlined';

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -574,10 +574,14 @@ const handleInputChange = (
               <PaginationItem
                 {...item}
                 onClick={() => {
-                  const idx = item.page - 1;
-                  if (idx !== conversationIndex) {
-                    setTransitionDir(idx > conversationIndex ? 'left' : 'right');
-                    setConversationIndex(idx);
+                  if (item.page != null) {
+                    const idx = item.page - 1;
+                    if (idx !== conversationIndex) {
+                      setTransitionDir(
+                        idx > conversationIndex ? 'left' : 'right'
+                      );
+                      setConversationIndex(idx);
+                    }
                   }
                 }}
               />


### PR DESCRIPTION
## Summary
- guard conversation pagination handling when `item.page` is null
- add missing TypeScript declarations for MUI icons

## Testing
- `node node_modules/react-scripts/scripts/build.js`
- `node node_modules/react-scripts/scripts/test.js --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68447cc371408332b8db64d53f4b605a