### PR TITLE
Fix input box scrolling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -172,7 +172,7 @@
   line-height: 1.4;
   transition: width 0.3s;
  max-height: 20vh;
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-wrap: anywhere;
   word-break: break-word;
 

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -351,8 +351,6 @@ const handleInputChange = (
   e: React.ChangeEvent<HTMLTextAreaElement>
 ) => {
   setText(e.target.value);
-  const targetId = replyTo?.id ?? messages[messages.length - 1]?.id;
-  scrollToMessage(targetId);
 
   const target = e.target as HTMLTextAreaElement;
   target.style.height = 'auto';
@@ -858,7 +856,7 @@ const handleInputChange = (
             onFocus={handleFocus}
             onBlur={handleBlur}
             placeholder="Type here..."
-            style={{ resize: 'none', overflow: 'auto' }}
+            style={{ resize: 'none', overflow: 'hidden' }}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- keep chat input at the bottom without scrolling while typing
- stop auto-scrolling chat when typing

## Testing
- `npm test --silent --maxWorkers=50` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab7b73548332b41fd351a2b0e4c9