### PR TITLE
Fix input keyboard and header

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,6 +32,8 @@
   max-width: 480px;
   margin: 0 auto;
   padding: 12px;
+  box-sizing: border-box;
+  width: 100%;
   height: 100dvh;
   display: flex;
   flex-direction: column;
@@ -172,7 +174,7 @@
   line-height: 1.4;
   transition: width 0.3s;
  max-height: 20vh;
-  overflow-y: auto;
+  overflow-y: hidden;
   overflow-wrap: anywhere;
   word-break: break-word;
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  height: 100dvh;
+  overflow: hidden;
 }
 
 code {

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -109,8 +109,6 @@ const ChatConversationPage: React.FC = () => {
   const [inputFocused, setInputFocused] = useState(false);
   const [generating, setGenerating] = useState(false);
 
-  const pageGestureRef = useRef({ startX: 0, startY: 0, dx: 0, dragging: false });
-  const [pageDragX, setPageDragX] = useState(0);
 
 
   const currentConversation = conversations[conversationIndex];
@@ -200,10 +198,10 @@ const handleSend = () => {
     setEditingId(null);
     setReplyTo(null);
     scrollToBottomIfNeeded();
-    setInputFocused(false);
+    setInputFocused(true);
     if (inputRef.current) {
       inputRef.current.style.height = 'auto';
-      inputRef.current.blur();
+      inputRef.current.focus();
     }
 };
 
@@ -351,8 +349,6 @@ const handleInputChange = (
   e: React.ChangeEvent<HTMLTextAreaElement>
 ) => {
   setText(e.target.value);
-  const targetId = replyTo?.id ?? messages[messages.length - 1]?.id;
-  scrollToMessage(targetId);
 
   const target = e.target as HTMLTextAreaElement;
   target.style.height = 'auto';
@@ -406,115 +402,16 @@ const handleInputChange = (
         height: '100dvh',
         display: 'flex',
         flexDirection: 'column',
-        transform: `translateX(${pageDragX}px)`,
-        transition: pageGestureRef.current.dragging ? 'none' : 'transform 0.3s',
+        boxSizing: 'border-box',
+        width: '100%',
+        transform: 'none',
+        transition: 'none',
       }}
       onClick={() => {
         setMenuId(null);
         setMenuPosition(null);
       }}
-      onTouchStart={(e) => {
-        const g = pageGestureRef.current;
-        g.startX = e.touches[0].clientX;
-        g.startY = e.touches[0].clientY;
-        g.dx = 0;
-        g.dragging = true;
-        setPageDragX(0);
-      }}
-      onTouchMove={(e) => {
-        const g = pageGestureRef.current;
-        if (!g.dragging) return;
-        g.dx = e.touches[0].clientX - g.startX;
-        setPageDragX(g.dx);
-      }}
-      onTouchCancel={() => {
-        const g = pageGestureRef.current;
-        g.dragging = false;
-        setPageDragX(0);
-
-      }}
-      onTouchEnd={(e) => {
-        const g = pageGestureRef.current;
-        if (!g.dragging) return;
-        const dx = e.changedTouches[0].clientX - g.startX;
-        const dy = e.changedTouches[0].clientY - g.startY;
-        g.dragging = false;
-        setPageDragX(0);
-
-        if (Math.abs(dx) > 50 && Math.abs(dy) < 30) {
-          if (dx < 0) {
-            if (conversationIndex === conversations.length - 1) {
-              setConversations((prev) => [
-                ...prev,
-                {
-                  id: `conv-${Math.random().toString(36).slice(2, 10)}`,
-                  startDateTime: new Date(),
-                  messages: [],
-                },
-              ]);
-              setConversationIndex((i) => i + 1);
-            } else {
-              setConversationIndex((i) => i + 1);
-            }
-            setTransitionDir('left');
-          } else if (dx > 0 && conversationIndex > 0) {
-            setConversationIndex((i) => i - 1);
-            setTransitionDir('right');
-
-          }
-        }
-      }}
-      onMouseDown={(e) => {
-        const g = pageGestureRef.current;
-        g.startX = e.clientX;
-        g.startY = e.clientY;
-        g.dx = 0;
-        g.dragging = true;
-        setPageDragX(0);
-      }}
-      onMouseMove={(e) => {
-        const g = pageGestureRef.current;
-        if (!g.dragging) return;
-        g.dx = e.clientX - g.startX;
-        setPageDragX(g.dx);
-      }}
-      onMouseLeave={() => {
-        const g = pageGestureRef.current;
-        g.dragging = false;
-        setPageDragX(0);
-
-      }}
-      onMouseUp={(e) => {
-        const g = pageGestureRef.current;
-        if (!g.dragging) return;
-        const dx = e.clientX - g.startX;
-        const dy = e.clientY - g.startY;
-        g.dragging = false;
-        setPageDragX(0);
-
-        if (Math.abs(dx) > 50 && Math.abs(dy) < 30) {
-          if (dx < 0) {
-            if (conversationIndex === conversations.length - 1) {
-              setConversations((prev) => [
-                ...prev,
-                {
-                  id: `conv-${Math.random().toString(36).slice(2, 10)}`,
-                  startDateTime: new Date(),
-                  messages: [],
-                },
-              ]);
-              setConversationIndex((i) => i + 1);
-            } else {
-              setConversationIndex((i) => i + 1);
-            }
-            setTransitionDir('left');
-          } else if (dx > 0 && conversationIndex > 0) {
-            setConversationIndex((i) => i - 1);
-            setTransitionDir('right');
-
-          }
-        }
-      }}
+      
     >
       <div className="chat-header">
         <Link to="/chat" className="back-icon">←</Link>
@@ -858,7 +755,7 @@ const handleInputChange = (
             onFocus={handleFocus}
             onBlur={handleBlur}
             placeholder="Type here..."
-            style={{ resize: 'none', overflow: 'auto' }}
+            style={{ resize: 'none', overflow: 'hidden' }}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- keep keyboard open after sending a message
- remove swipe gesture navigation
- prevent body scrolling so header stays visible

## Testing
- `npm test --silent --maxWorkers=50`


------
https://chatgpt.com/codex/tasks/task_e_6844ab7b73548332b41fd351a2b0e4c9