### PR TITLE
Align schedule button with execution time

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -497,23 +497,22 @@ const handleInputChange = (
       >
         <span style={{ fontSize: 14 }}>Executed at</span>
         <DateTimePicker onChange={(d) => d && updateStartDateTime(d)} value={startDateTime} />
+        <Button
+          className="generate-btn"
+          onClick={handleGenerateAI}
+          disabled={generating}
+          style={{ width: 'auto' }}
+        >
+          {generating ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            <>
+              <AutoAwesomeIcon style={{ marginRight: 4 }} />
+              Schedule
+            </>
+          )}
+        </Button>
       </div>
-      <Button
-        className="generate-btn"
-        onClick={handleGenerateAI}
-        disabled={generating}
-        fullWidth
-        style={{ marginBottom: 8 }}
-      >
-        {generating ? (
-          <CircularProgress size={20} color="inherit" />
-        ) : (
-          <>
-            <AutoAwesomeIcon style={{ marginRight: 4 }} />
-            Generate a conversation with AI
-          </>
-        )}
-      </Button>
       <div
         className={`chat-messages ${
           transitionDir ? `animate-${transitionDir}` : ''


### PR DESCRIPTION
## Summary
- change the AI generation button label to **Schedule**
- place the schedule button next to the "Executed at" label and date time picker

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68453dc9841883329fa2b36fa24eb501