### PR TITLE
Add Telegram init data display

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders go to chat button', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const btnElement = screen.getByRole('button', { name: /go to chat/i });
+  expect(btnElement).toBeInTheDocument();
 });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,24 +1,63 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import logo from '../logo.svg';
 import '../App.css';
 
-const HomePage: React.FC = () => (
-  <div className="App">
-    <header className="App-header">
-      <img src={logo} className="App-logo" alt="logo" />
-      <p>
-        Edit <code>src/App.tsx</code> and save to reload.
-      </p>
-      <a
-        className="App-link"
-        href="https://reactjs.org"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Learn React
-      </a>
-    </header>
-  </div>
-);
+interface TelegramInitData {
+  user?: {
+    id: number;
+    first_name: string;
+    last_name?: string;
+    username?: string;
+    language_code?: string;
+  };
+  [key: string]: any;
+}
+
+const HomePage: React.FC = () => {
+  const navigate = useNavigate();
+  const [initData, setInitData] = useState<TelegramInitData | null>(null);
+
+  useEffect(() => {
+    const tg = (window as any).Telegram?.WebApp;
+    if (tg && tg.initDataUnsafe) {
+      setInitData(tg.initDataUnsafe);
+      try {
+        localStorage.setItem('tg_init_data', JSON.stringify(tg.initDataUnsafe));
+      } catch {
+        // ignore write errors
+      }
+    }
+  }, []);
+
+  return (
+    <div className="App">
+      <header className="App-header">
+        <img src={logo} className="App-logo" alt="logo" />
+        {initData?.user && (
+          <p>
+            Logged in as {initData.user.first_name}{' '}
+            {initData.user.last_name ?? ''}
+            {initData.user.username ? ` (@${initData.user.username})` : ''}
+          </p>
+        )}
+        {initData && (
+          <pre
+            style={{
+              textAlign: 'left',
+              background: '#282c34',
+              padding: '1rem',
+              maxWidth: 300,
+              overflowX: 'auto',
+            }}
+          >
+            {JSON.stringify(initData, null, 2)}
+          </pre>
+        )}
+        <button onClick={() => navigate('/chat')}>Go to Chat</button>
+      </header>
+    </div>
+  );
+};
 
 export default HomePage;


### PR DESCRIPTION
## Summary
- capture Telegram init data on the home page
- store the init data in localStorage
- add button to navigate to chat page
- update test to check new UI

## Testing
- `npm test --silent -- --runTestsByPath src/App.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_684542d52d0c8332894cc8f60d6a1a29