### PR TITLE
Align schedule button with execution time

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -350,6 +350,13 @@
   box-shadow: 0 0 6px rgba(0, 198, 255, 0.6);
 }
 
+.schedule-btn {
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 8px;
+  width: auto;
+}
+
 .inbox-header {
   display: flex;
   justify-content: space-between;

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -101,6 +101,8 @@ const ChatConversationPage: React.FC = () => {
     { id: null, dx: 0 }
   );
   const [delayMenuId, setDelayMenuId] = useState<number | null>(null);
+  const [delayMenuPosition, setDelayMenuPosition] =
+    useState<{ x: number; y: number } | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
 
@@ -411,6 +413,8 @@ const handleInputChange = (
       onClick={() => {
         setMenuId(null);
         setMenuPosition(null);
+        setDelayMenuId(null);
+        setDelayMenuPosition(null);
       }}
       
     >
@@ -497,23 +501,21 @@ const handleInputChange = (
       >
         <span style={{ fontSize: 14 }}>Executed at</span>
         <DateTimePicker onChange={(d) => d && updateStartDateTime(d)} value={startDateTime} />
+        <Button
+          className="generate-btn schedule-btn"
+          onClick={handleGenerateAI}
+          disabled={generating}
+        >
+          {generating ? (
+            <CircularProgress size={20} color="inherit" />
+          ) : (
+            <>
+              <AutoAwesomeIcon style={{ marginRight: 4 }} />
+              Schedule
+            </>
+          )}
+        </Button>
       </div>
-      <Button
-        className="generate-btn"
-        onClick={handleGenerateAI}
-        disabled={generating}
-        fullWidth
-        style={{ marginBottom: 8 }}
-      >
-        {generating ? (
-          <CircularProgress size={20} color="inherit" />
-        ) : (
-          <>
-            <AutoAwesomeIcon style={{ marginRight: 4 }} />
-            Generate a conversation with AI
-          </>
-        )}
-      </Button>
       <div
         className={`chat-messages ${
           transitionDir ? `animate-${transitionDir}` : ''
@@ -534,9 +536,14 @@ const handleInputChange = (
               {idx > 0 && (
                 <span
                   className={`delay-wrapper ${me ? 'left' : 'right'}`}
-                  onClick={() =>
-                    setDelayMenuId(delayMenuId === msg.id ? null : msg.id)
-                  }
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    const rect = (
+                      e.currentTarget as HTMLElement
+                    ).getBoundingClientRect();
+                    setDelayMenuPosition({ x: rect.right, y: rect.top - 40 });
+                    setDelayMenuId(delayMenuId === msg.id ? null : msg.id);
+                  }}
                 >
                   <IconButton
                     className="delay-btn"
@@ -546,7 +553,14 @@ const handleInputChange = (
                     <TimerIcon fontSize="inherit" />
                   </IconButton>
                   {delayMenuId === msg.id && (
-                    <div className={`message-menu ${me ? 'left' : 'right'}`}>
+                    <div
+                      className="message-menu"
+                      style={{
+                        left: delayMenuPosition?.x,
+                        top: delayMenuPosition?.y,
+                      }}
+                      onMouseDown={(e) => e.stopPropagation()}
+                    >
                       <button onClick={() => handleResetDelay(msg.id)}>Reset</button>
                       {[1, 2, 3, 5].map((m) => (
                         <button


### PR DESCRIPTION
## Summary
- change AI generation button label to **Schedule** and size it smaller
- show delay menu next to the timer icon that was clicked
- stop the chat click handler from closing the delay menu immediately

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68453dc9841883329fa2b36fa24eb501