### PR TITLE
Fix delay icon menu and move date picker

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -283,6 +283,9 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 2;
 }
+.header-datetime {
+  margin-left: auto;
+}
 
 .conversation-nav {
   display: flex;

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -426,6 +426,11 @@ const handleInputChange = (
           alt={id}
         />
         <span className="header-name">{id}</span>
+        <DateTimePicker
+          className="header-datetime"
+          onChange={(d) => d && updateStartDateTime(d)}
+          value={startDateTime}
+        />
       </div>
       <div className="conversation-nav">
         <Pagination
@@ -499,8 +504,6 @@ const handleInputChange = (
         className="start-time-inputs"
         style={{ display: 'flex', gap: 4, marginBottom: 8, alignItems: 'center' }}
       >
-        <span style={{ fontSize: 14 }}>Executed at</span>
-        <DateTimePicker onChange={(d) => d && updateStartDateTime(d)} value={startDateTime} />
         <Button
           className="generate-btn schedule-btn"
           onClick={handleGenerateAI}
@@ -538,6 +541,7 @@ const handleInputChange = (
                 <span
                   className={`delay-wrapper ${me ? 'left' : 'right'}`}
                   onClick={(e) => {
+                    e.stopPropagation();
                     const rect = (
                       e.currentTarget as HTMLElement
                     ).getBoundingClientRect();


### PR DESCRIPTION
## Summary
- stop click event propagation for delay icon
- show the date/time picker in the chat header
- remove the outdated "Executed at" label

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68454d4030b48332aa3203adc0a07417