### PR TITLE
Implement ledger scheduling and status categorization

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -105,7 +105,23 @@ const ChatInboxPage: React.FC = () => {
       });
   }, []);
 
-  const executedChats = groups.map((g) => ({
+  const executedGroups = groups.filter((g) =>
+    g.conversations?.some((c: any) =>
+      c.messages?.some((m: any) => m.status === 'executed')
+    )
+  );
+  const scheduledGroups = groups.filter((g) =>
+    g.conversations?.some((c: any) =>
+      c.messages?.some((m: any) => m.status === 'pending')
+    )
+  );
+  const draftGroups = groups.filter((g) =>
+    g.conversations?.some((c: any) =>
+      c.messages?.some((m: any) => !m.status || m.status === 'draft')
+    )
+  );
+
+  const mapChat = (g: any) => ({
     id: g.groupId,
     avatar: '',
     alt: g.groupId,
@@ -115,10 +131,11 @@ const ChatInboxPage: React.FC = () => {
       '',
     date: new Date(),
     unread: 0,
-  }));
+  });
 
-  const scheduledChats = executedChats;
-  const draftChats: typeof executedChats = [];
+  const executedChats = executedGroups.map(mapChat);
+  const scheduledChats = scheduledGroups.map(mapChat);
+  const draftChats = draftGroups.map(mapChat);
 
   const [tabIndex, setTabIndex] = useState(0);
   const [viewportHeight, setViewportHeight] = useState<number>(


### PR DESCRIPTION
## Summary
- track message status for conversations
- post ledger JSON to `/api/ledger` when scheduling
- mark messages as `pending` on schedule
- categorize chats into executed/scheduled/draft tabs

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845780128e48332b656fd339c6136d6