### PR TITLE
Adjust chat layout for viewport

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -29,14 +29,13 @@
 }
 
 .chat-container {
-  max-width: 480px;
-  margin: 0 auto;
-  padding: 12px;
-  box-sizing: border-box;
   width: 100%;
   height: 100dvh;
   display: flex;
   flex-direction: column;
+  box-sizing: border-box;
+  padding: 0;
+  margin: 0;
 }
 
 .chat-messages {
@@ -158,12 +157,12 @@
   bottom: 0;
   left: 0;
   right: 0;
-  max-width: 480px;
-  margin: 0 auto;
   padding: 8px;
   background: #fff;
   border-top: 1px solid #ccc;
   transition: all 0.3s;
+  width: 100%;
+  margin: 0;
 }
 
 .message-input-container.focused .MuiIconButton-root:not(.send-button) {
@@ -253,10 +252,10 @@
   bottom: 60px;
   left: 0;
   right: 0;
-  max-width: 480px;
-  margin: 0 auto;
   padding: 8px;
   z-index: 5;
+  width: 100%;
+  margin: 0;
 }
 
 .reply-preview {
@@ -289,9 +288,12 @@
   color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   z-index: 2;
+  flex-wrap: wrap;
 }
 .header-datetime {
   margin-left: auto;
+  flex-shrink: 0;
+  flex-basis: auto;
 }
 
 .conversation-nav {
@@ -320,6 +322,7 @@
 .header-name {
   font-weight: bold;
   color: #fff;
+  overflow-wrap: anywhere;
 }
 
 .instruction-text {


### PR DESCRIPTION
## Summary
- ensure chat layout uses full viewport width
- make message input and reply preview full width
- allow chat header to wrap and move date picker down when needed

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684581f6cb8c8332af12e5e59d4b79c8