### PR TITLE
Remove unused variable causing build error

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -248,15 +248,6 @@ const ChatInboxPage: React.FC = () => {
 
 
 
-  const mapUserGroup = (g: any) => ({
-    id: g.group.id,
-    avatar: '',
-    alt: g.group.title,
-    title: g.group.title,
-    subtitle: g.group.username ? `@${g.group.username}` : '',
-    date: new Date(),
-    unread: g.group.online_count ?? 0,
-  });
   const [viewportHeight, setViewportHeight] = useState<number>(
     typeof window !== 'undefined' ? window.innerHeight : 0
   );


### PR DESCRIPTION
## Summary
- remove unused `mapUserGroup` function

## Testing
- `CI=true node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_6845e7553b388332a59b61ac8b143f7c