### PR TITLE
Fix group list view

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -244,7 +244,7 @@ const ChatInboxPage: React.FC = () => {
   const executedChats = executedGroups.map(mapChat);
   const scheduledChats = scheduledGroups.map(mapChat);
   const draftChats = draftGroups.map(mapChat);
- const groupChats = groups.map(mapChat);
+  const groupChats = (userGroups.length ? userGroups : groups).map(mapChat);
 
 
 
@@ -366,8 +366,7 @@ const ChatInboxPage: React.FC = () => {
       <TabPanel value={tabIndex} index={3}>
         <ChatList
           className="chat-list"
-        dataSource={groupChats}
-
+          dataSource={groupChats}
           onClick={(item: any) => {
             navigate(`/chat/${(item as any).id}`);
           }}


### PR DESCRIPTION
## Summary
- compute Group List tab entries from user-specific groups
- use the computed list for the Group List tab

## Testing
- `npm test -- -w=ci --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6845f2c469848332b1d57e5373d3aa00