### PR TITLE
Fix dark mode chat list styles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -420,6 +420,47 @@
 
 }
 
+/* Chat list items */
+.chat-list .rce-citem {
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--tg-border-color);
+  background: var(--tg-secondary-bg-color);
+}
+
+.chat-list .rce-citem-avatar img {
+  width: 40px;
+  height: 40px;
+  margin-right: 12px;
+}
+
+.chat-list .rce-citem-body--bottom-title,
+.chat-list .rce-citem-body--top-time,
+.chat-list .rce-citem-body--top-title {
+  color: var(--tg-text-color);
+}
+
+.chat-list .rce-citem-body--top-title {
+  white-space: normal;
+}
+
+.fab .MuiFab-root {
+  background-color: #03a9f4;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s;
+}
+
+.fab .MuiFab-root:hover {
+  transform: scale(1.1);
+}
+
+.empty-message {
+  color: #888;
+  text-align: center;
+  margin-top: 40px;
+}
+
 
 
 @keyframes App-logo-spin {

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -384,40 +384,60 @@ const ChatInboxPage: React.FC = () => {
         </Tabs>
       </Box>
       <TabPanel value={tabIndex} index={0}>
-        <ChatList
-          className="chat-list"
-          dataSource={executedChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {executedChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={executedChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">
+            No executed messages yet. Tap + to create one.
+          </p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={1}>
-        <ChatList
-          className="chat-list"
-          dataSource={scheduledChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {scheduledChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={scheduledChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">
+            No scheduled messages yet. Tap + to create one.
+          </p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={2}>
-        <ChatList
-          className="chat-list"
-          dataSource={draftChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {draftChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={draftChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">No drafts yet. Tap + to create one.</p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={3}>
-        <ChatList
-          className="chat-list"
-          dataSource={groupChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {groupChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={groupChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">No groups found. Tap + to add one.</p>
+        )}
       </TabPanel>
 
       <SpeedDial
@@ -427,6 +447,7 @@ const ChatInboxPage: React.FC = () => {
         onOpen={() => setSpeedDialOpen(true)}
         onClose={() => setSpeedDialOpen(false)}
         sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        className="fab"
       >
         <SpeedDialAction
           icon={<GroupAddIcon />}


### PR DESCRIPTION
## Summary
- style chat list items for dark mode
- add floating button style and empty state placeholders

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f685ef8c8332a2de6b4d5cc47f1c