### PR TITLE
Improve chat inbox UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -414,10 +414,79 @@
   background: var(--tg-bg-color);
 }
 
+.chat-tabs .MuiTab-root {
+  text-transform: none;
+  font-weight: 500;
+  color: var(--tg-text-color);
+}
+
+.chat-tabs .MuiTab-root.Mui-selected {
+  font-weight: bold;
+  color: var(--tg-button-color);
+}
+
+.chat-tabs .MuiTabs-indicator {
+  background-color: var(--tg-button-color);
+}
+
 .chat-list {
   background: var(--tg-secondary-bg-color);
   color: var(--tg-text-color);
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 72px;
 
+}
+
+/* Chat list items */
+.chat-list .rce-citem {
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--tg-border-color);
+  background: var(--tg-secondary-bg-color);
+}
+
+.chat-list .rce-citem-avatar img {
+  width: 40px;
+  height: 40px;
+  margin-right: 12px;
+}
+
+.chat-list .rce-citem-body--top-title {
+  color: var(--tg-text-color);
+  font-weight: bold;
+  white-space: normal;
+}
+
+.chat-list .rce-citem-body--bottom-title {
+  color: #aaa;
+}
+
+.chat-list .rce-citem-body--top-time {
+  color: #aaa;
+}
+
+.tab-panel {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.fab .MuiFab-root {
+  background-color: #03a9f4;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s;
+}
+
+.fab .MuiFab-root:hover {
+  transform: scale(1.1);
+}
+
+.empty-message {
+  color: #888;
+  text-align: center;
+  margin-top: 40px;
 }
 
 

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -44,8 +44,13 @@ function TabPanel(props: TabPanelProps) {
       id={`chat-tabpanel-${index}`}
       aria-labelledby={`chat-tab-${index}`}
       {...other}
+      className="tab-panel"
     >
-      {value === index && <Box sx={{ p: 0 }}>{children}</Box>}
+      {value === index && (
+        <Box sx={{ p: 0, flex: 1, display: 'flex', flexDirection: 'column' }}>
+          {children}
+        </Box>
+      )}
     </div>
   );
 }
@@ -229,17 +234,24 @@ const ChatInboxPage: React.FC = () => {
     )
   );
 
-  const mapChat = (g: any) => ({
-    id: g.groupId,
-    avatar: '',
-    alt: g.groupId,
-    title: g.groupId,
-    subtitle:
-      g.conversations?.[g.conversations.length - 1]?.messages?.slice(-1)[0]?.text ||
-      '',
-    date: new Date(),
-    unread: 0,
-  });
+  const mapChat = (g: any) => {
+    const conversations = g.conversations || [];
+    const lastConv = conversations[conversations.length - 1] || {};
+    const lastMsg = lastConv.messages?.slice(-1)[0] || {};
+    const name = g.title || g.name || `Group ${g.groupId ?? g.id}`;
+    return {
+      id: g.groupId ?? g.id,
+      avatar: g.photo || '',
+      alt: name,
+      title: name,
+      subtitle: lastMsg.text || '',
+      date: lastMsg.createdAt ? new Date(lastMsg.createdAt) : undefined,
+      dateString: lastMsg.createdAt
+        ? new Date(lastMsg.createdAt).toLocaleString()
+        : undefined,
+      unread: 0,
+    };
+  };
 
   const executedChats = executedGroups.map(mapChat);
   const scheduledChats = scheduledGroups.map(mapChat);
@@ -376,6 +388,8 @@ const ChatInboxPage: React.FC = () => {
           value={tabIndex}
           onChange={(_, newValue) => setTabIndex(newValue)}
           aria-label="chat tabs"
+          className="chat-tabs"
+          variant="fullWidth"
         >
           <Tab label="Executed" {...a11yProps(0)} />
           <Tab label="Scheduled" {...a11yProps(1)} />
@@ -384,40 +398,60 @@ const ChatInboxPage: React.FC = () => {
         </Tabs>
       </Box>
       <TabPanel value={tabIndex} index={0}>
-        <ChatList
-          className="chat-list"
-          dataSource={executedChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {executedChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={executedChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">
+            No executed messages yet. Tap + to create one.
+          </p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={1}>
-        <ChatList
-          className="chat-list"
-          dataSource={scheduledChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {scheduledChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={scheduledChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">
+            No scheduled messages yet. Tap + to create one.
+          </p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={2}>
-        <ChatList
-          className="chat-list"
-          dataSource={draftChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {draftChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={draftChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">No drafts yet. Tap + to create one.</p>
+        )}
       </TabPanel>
       <TabPanel value={tabIndex} index={3}>
-        <ChatList
-          className="chat-list"
-          dataSource={groupChats}
-          onClick={(item: any) => {
-            navigate(`/chat/${(item as any).id}`);
-          }}
-        />
+        {groupChats.length ? (
+          <ChatList
+            className="chat-list"
+            dataSource={groupChats}
+            onClick={(item: any) => {
+              navigate(`/chat/${(item as any).id}`);
+            }}
+          />
+        ) : (
+          <p className="empty-message">No groups found. Tap + to add one.</p>
+        )}
       </TabPanel>
 
       <SpeedDial
@@ -427,6 +461,7 @@ const ChatInboxPage: React.FC = () => {
         onOpen={() => setSpeedDialOpen(true)}
         onClose={() => setSpeedDialOpen(false)}
         sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        className="fab"
       >
         <SpeedDialAction
           icon={<GroupAddIcon />}


### PR DESCRIPTION
## Summary
- style tabs for better visibility and keep case
- allow chat list to scroll and avoid FAB overlap
- refine chat item spacing and colors
- show group names and last message info

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f685ef8c8332a2de6b4d5cc47f1c