### PR TITLE
Fix group list parsing

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -206,7 +206,10 @@ const ChatInboxPage: React.FC = () => {
     )
       .then((r) => r.json())
       .then((data) => {
-        setUserGroups(data.groups || []);
+        const groups = Array.isArray(data.groups)
+          ? data.groups.map((g: any) => g.group || g)
+          : [];
+        setUserGroups(groups);
       })
       .catch(() => setUserGroups([]));
   }, [tabIndex, userGroups.length]);


### PR DESCRIPTION
## Summary
- parse groups API response to extract nested group objects

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684601ab38e08332b135e574d9de4d65