### PR TITLE
Improve chat inbox UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -414,10 +414,108 @@
   background: var(--tg-bg-color);
 }
 
+.chat-tabs .MuiTab-root {
+  text-transform: none;
+  font-weight: 500;
+  color: var(--tg-text-color);
+}
+
+.chat-tabs .MuiTab-root.Mui-selected {
+  font-weight: bold;
+  color: var(--tg-button-color);
+}
+
+.chat-tabs {
+  min-height: 48px;
+}
+
+.chat-tabs .MuiTab-root {
+  flex: 1;
+  min-height: 48px;
+}
+
+.chat-tabs .MuiTabs-flexContainer {
+  align-items: center;
+}
+
+.chat-tabs .MuiTabs-indicator {
+  background-color: var(--tg-button-color);
+  height: 3px;
+  border-radius: 2px;
+}
+
 .chat-list {
   background: var(--tg-secondary-bg-color);
   color: var(--tg-text-color);
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 72px;
 
+}
+
+/* Chat list items */
+.chat-list .rce-citem {
+  padding: 8px 12px;
+  display: flex;
+  align-items: center;
+  border-bottom: 1px solid var(--tg-border-color);
+  background: var(--tg-secondary-bg-color);
+  min-height: 64px;
+  box-sizing: border-box;
+}
+
+.chat-list .rce-citem-avatar img {
+  width: 40px;
+  height: 40px;
+  margin-right: 12px;
+  object-fit: cover;
+  border-radius: 50%;
+}
+
+.chat-list .rce-citem-body--top-title {
+  color: var(--tg-text-color);
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.chat-list .rce-citem-body--bottom-title {
+  color: #aaa;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chat-list .rce-citem-body--top-time {
+  color: #aaa;
+  white-space: nowrap;
+}
+
+.tab-panel {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.tab-panel[hidden] {
+  display: none !important;
+}
+
+.fab .MuiFab-root {
+  background-color: #03a9f4;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s;
+}
+
+.fab .MuiFab-root:hover {
+  transform: scale(1.1);
+}
+
+.empty-message {
+  color: #888;
+  text-align: center;
+  margin-top: 40px;
 }
 
 


### PR DESCRIPTION
## Summary
- adjust tab styling for proper alignment and bold active indicator
- normalize group names and ignore numeric IDs
- keep chat items uniform height and truncate long text
- hide inactive tab panels so only the active panel is rendered

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845f685ef8c8332a2de6b4d5cc47f1c