### PR TITLE
Use stable UUIDs in chat data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react-router-dom": "^6.30.1",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
+        "uuid": "^11.1.0",
         "web-vitals": "^2.1.4"
       }
     },
@@ -16163,6 +16164,15 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -17724,12 +17734,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-scripts": "5.0.1",
     "@telegram-apps/sdk-react": "^3.3.0",
     "typescript": "^4.9.5",
+    "uuid": "^11.1.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {

--- a/src/App.css
+++ b/src/App.css
@@ -299,12 +299,19 @@
   flex-shrink: 0;
   flex-basis: auto;
 }
+.header-datetime input,
+.header-datetime .react-datetime-picker__inputGroup {
+  color: #000;
+}
 
 .conversation-nav {
   display: flex;
   justify-content: center;
   gap: 4px;
   margin-bottom: 8px;
+}
+body.tg-dark .conversation-nav .MuiPaginationItem-root {
+  color: #fff;
 }
 
 

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import IconButton from '@mui/material/IconButton';
 import SendIcon from '@mui/icons-material/Send';
 import CodeIcon from '@mui/icons-material/Code';
@@ -52,6 +53,7 @@ const avatars: Avatar[] = [
 
 interface Message {
   id: number;
+  uuid: string;
   from: string;
   text: string;
   delay: number;
@@ -68,15 +70,14 @@ interface Conversation {
 }
 
 const initialMessages: Record<string, Message[]> = {
-  kursat: [{ id: 1, from: 'kursat', text: "Why don't we go to the mall this weekend ?", delay: 0, status: 'draft' }],
-  emre: [{ id: 1, from: 'emre', text: 'Send me our photos.', delay: 0, status: 'draft' }],
-  abdurrahim: [{ id: 1, from: 'abdurrahim', text: 'Hey ! Send me the animation video please.', delay: 0, status: 'draft' }],
-  esra: [{ id: 1, from: 'esra', text: 'I need a random voice.', delay: 0, status: 'draft' }],
-  bensu: [{ id: 1, from: 'bensu', text: 'Send your location.', delay: 0, status: 'draft' }],
-  burhan: [{ id: 1, from: 'burhan', text: 'Recommend me some songs.', delay: 0, status: 'draft' }],
-  abdurrahman: [{ id: 1, from: 'abdurrahman', text: 'Where is the presentation file ?', delay: 0, status: 'draft' }],
-  ahmet: [{ id: 1, from: 'ahmet', text: "Let's join the daily meeting.", delay: 0, status: 'draft' }],
-
+  kursat: [{ id: 1, uuid: uuidv4(), from: 'kursat', text: "Why don't we go to the mall this weekend ?", delay: 0, status: 'draft' }],
+  emre: [{ id: 1, uuid: uuidv4(), from: 'emre', text: 'Send me our photos.', delay: 0, status: 'draft' }],
+  abdurrahim: [{ id: 1, uuid: uuidv4(), from: 'abdurrahim', text: 'Hey ! Send me the animation video please.', delay: 0, status: 'draft' }],
+  esra: [{ id: 1, uuid: uuidv4(), from: 'esra', text: 'I need a random voice.', delay: 0, status: 'draft' }],
+  bensu: [{ id: 1, uuid: uuidv4(), from: 'bensu', text: 'Send your location.', delay: 0, status: 'draft' }],
+  burhan: [{ id: 1, uuid: uuidv4(), from: 'burhan', text: 'Recommend me some songs.', delay: 0, status: 'draft' }],
+  abdurrahman: [{ id: 1, uuid: uuidv4(), from: 'abdurrahman', text: 'Where is the presentation file ?', delay: 0, status: 'draft' }],
+  ahmet: [{ id: 1, uuid: uuidv4(), from: 'ahmet', text: "Let's join the daily meeting.", delay: 0, status: 'draft' }],
 };
 
 
@@ -86,7 +87,7 @@ const ChatConversationPage: React.FC = () => {
   const initialStart = new Date();
   const [conversations, setConversations] = useState<Conversation[]>([
     {
-      id: `conv-${Math.random().toString(36).slice(2, 10)}`,
+      id: uuidv4(),
       startDateTime: initialStart,
       messages: initialMessages[id ?? ''] || [],
     },
@@ -120,7 +121,7 @@ const ChatConversationPage: React.FC = () => {
       const g = groups.find((gr: any) => gr.groupId === id);
       if (g && g.conversations) {
         const convs: Conversation[] = g.conversations.map((c: any) => ({
-          id: c.conversationId || c.id,
+          id: c.conversationId || c.id || uuidv4(),
           startDateTime: new Date(c.createdAt || new Date()),
           messages: (c.messages || []).map((m: any, idx: number) => {
             const type = (c.type || '').toLowerCase();
@@ -130,6 +131,7 @@ const ChatConversationPage: React.FC = () => {
 
             return {
               id: idx + 1,
+              uuid: m.message_id || m.uuid || uuidv4(),
               from: m.sender_id || m.from || avatars[0].id,
               text: m.text || m.message_content || '',
               delay: 0,
@@ -199,7 +201,7 @@ const ChatConversationPage: React.FC = () => {
           const relative = idx === 0 ? 0 : m.delay * 60;
 
           return {
-            message_id: `m-${m.id}`,
+            message_id: m.uuid,
             sender_id: m.from,
             sender_name: m.from,
             message_content: m.text,
@@ -364,6 +366,7 @@ const handleSend = () => {
       ...prev,
       {
         id: newId,
+        uuid: uuidv4(),
         from: selectedAvatar.id,
         text,
         delay: 0,
@@ -468,6 +471,7 @@ const handleSend = () => {
         const from = others[i % count].id;
         generated.push({
           id: ++nextId,
+          uuid: uuidv4(),
           from,
           text: `Auto message ${i + 1}`,
           delay: 0,
@@ -607,13 +611,11 @@ const handleInputChange = (
                     if (isLast) {
                       setConversations((prev) => [
                         ...prev,
-                        {
-                          id: `conv-${Math.random()
-                            .toString(36)
-                            .slice(2, 10)}`,
-                          startDateTime: new Date(),
-                          messages: [],
-                        },
+                          {
+                            id: uuidv4(),
+                            startDateTime: new Date(),
+                            messages: [],
+                          },
                       ]);
                       setConversationIndex(conversations.length);
                     } else {
@@ -643,9 +645,6 @@ const handleInputChange = (
           }}
         />
 
-      </div>
-      <div className="instruction-text">
-        You are creating messages. The AI will execute these messages.
       </div>
       <div
         className="start-time-inputs"

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -15,6 +15,7 @@ import SpeedDialAction from '@mui/material/SpeedDialAction';
 import GroupAddIcon from '@mui/icons-material/GroupAdd';
 import SettingsSuggestIcon from '@mui/icons-material/SettingsSuggest';
 import SmartToyIcon from '@mui/icons-material/SmartToy';
+import TimerIcon from '@mui/icons-material/Timer';
 import Dialog from '@mui/material/Dialog';
 import DialogTitle from '@mui/material/DialogTitle';
 import DialogContent from '@mui/material/DialogContent';
@@ -278,6 +279,11 @@ const ChatInboxPage: React.FC = () => {
     typeof window !== 'undefined' ? window.innerHeight : 0
   );
   const [speedDialOpen, setSpeedDialOpen] = useState(false);
+  const [speedDialPos, setSpeedDialPos] = useState(() => ({
+    x: typeof window !== 'undefined' ? window.innerWidth - 80 : 300,
+    y: typeof window !== 'undefined' ? window.innerHeight - 80 : 400,
+  }));
+  const [draggingDial, setDraggingDial] = useState(false);
   const [groupDialogOpen, setGroupDialogOpen] = useState(false);
   const [selectedGroups, setSelectedGroups] = useState<string[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
@@ -388,6 +394,20 @@ const ChatInboxPage: React.FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (!draggingDial) return;
+    const handleMove = (e: PointerEvent) => {
+      setSpeedDialPos((pos) => ({ x: pos.x + e.movementX, y: pos.y + e.movementY }));
+    };
+    const stop = () => setDraggingDial(false);
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', stop);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', stop);
+    };
+  }, [draggingDial]);
+
 
   return (
     <div className="chat-container" style={{ height: viewportHeight }}>
@@ -475,8 +495,13 @@ const ChatInboxPage: React.FC = () => {
         open={speedDialOpen}
         onOpen={() => setSpeedDialOpen(true)}
         onClose={() => setSpeedDialOpen(false)}
-        sx={{ position: 'absolute', bottom: 16, right: 16 }}
+        sx={{ position: 'absolute', top: speedDialPos.y, left: speedDialPos.x }}
         className="fab"
+        onPointerDown={(e) => {
+          if ((e.target as HTMLElement).closest('.MuiSpeedDial-fab')) {
+            setDraggingDial(true);
+          }
+        }}
       >
         <SpeedDialAction
           icon={<GroupAddIcon />}
@@ -507,6 +532,14 @@ const ChatInboxPage: React.FC = () => {
                   'selected groups'}...`
               );
             }
+          }}
+        />
+        <SpeedDialAction
+          icon={<TimerIcon />}
+          tooltipTitle="Schedule"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            navigate('/chat');
           }}
         />
       </SpeedDial>


### PR DESCRIPTION
## Summary
- generate uuid for example messages and conversations
- include uuid in exported data
- remove leftover instruction message
- make navigation white in dark mode
- add draggable speed dial with schedule button

## Testing
- `npm install`
- `CI=true npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684609bda138833284e8cbfe41cdfbcf