### PR TITLE
Restore speed dial on chat page

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -11,6 +11,9 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import DeleteIcon from '@mui/icons-material/Delete';
 import AutoAwesomeIcon from '@mui/icons-material/AutoAwesome';
 import CircularProgress from '@mui/material/CircularProgress';
+import SpeedDial from '@mui/material/SpeedDial';
+import SpeedDialIcon from '@mui/material/SpeedDialIcon';
+import SpeedDialAction from '@mui/material/SpeedDialAction';
 
 // SpeedDial features moved to ChatInboxPage
 import Dialog from '@mui/material/Dialog';
@@ -187,6 +190,12 @@ const ChatConversationPage: React.FC = () => {
   const [jsonOpen, setJsonOpen] = useState(false);
   const [inputFocused, setInputFocused] = useState(false);
   const [generating, setGenerating] = useState(false);
+  const [speedDialOpen, setSpeedDialOpen] = useState(false);
+  const [speedDialPos, setSpeedDialPos] = useState(() => ({
+    x: typeof window !== 'undefined' ? window.innerWidth - 80 : 300,
+    y: typeof window !== 'undefined' ? window.innerHeight - 80 : 400,
+  }));
+  const [draggingDial, setDraggingDial] = useState(false);
 
   const generateJSON = useCallback(
     (convList: Conversation[] = conversations) => {
@@ -538,6 +547,20 @@ const handleInputChange = (
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  useEffect(() => {
+    if (!draggingDial) return;
+    const handleMove = (e: PointerEvent) => {
+      setSpeedDialPos((pos) => ({ x: pos.x + e.movementX, y: pos.y + e.movementY }));
+    };
+    const stop = () => setDraggingDial(false);
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', stop);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', stop);
+    };
+  }, [draggingDial]);
 
   const headerName = (() => {
     const base = groupInfo?.title || groupInfo?.name || groupInfo?.username || '';
@@ -975,6 +998,46 @@ const handleInputChange = (
           <Button onClick={() => setJsonOpen(false)}>Close</Button>
         </DialogActions>
       </Dialog>
+
+      <SpeedDial
+        ariaLabel="chat actions"
+        icon={<SpeedDialIcon />}
+        open={speedDialOpen}
+        onOpen={() => setSpeedDialOpen(true)}
+        onClose={() => setSpeedDialOpen(false)}
+        sx={{ position: 'fixed', top: speedDialPos.y, left: speedDialPos.x, zIndex: 1500 }}
+        className="fab"
+        onPointerDown={(e) => {
+          if ((e.target as HTMLElement).closest('.MuiSpeedDial-fab')) {
+            setDraggingDial(true);
+          }
+        }}
+      >
+        <SpeedDialAction
+          icon={<CodeIcon />}
+          tooltipTitle="Show JSON"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            setJsonOpen(true);
+          }}
+        />
+        <SpeedDialAction
+          icon={<SmartToyIcon />}
+          tooltipTitle="Auto Chat"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            handleGenerateBotMessages();
+          }}
+        />
+        <SpeedDialAction
+          icon={<TimerIcon />}
+          tooltipTitle="Schedule"
+          onClick={() => {
+            setSpeedDialOpen(false);
+            handleSchedule();
+          }}
+        />
+      </SpeedDial>
 
 
     </div>


### PR DESCRIPTION
## Summary
- add SpeedDial imports
- manage SpeedDial position and dragging
- show a draggable SpeedDial with actions to show JSON, auto chat, and schedule

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684613f43f1883329faba7dd803355f4