### PR TITLE
Bring speed dials to front

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -520,7 +520,7 @@ body.tg-dark .conversation-nav .MuiPaginationItem-root {
 
 .fab {
   position: fixed;
-  z-index: 1500;
+  z-index: 9999;
 }
 
 .fab .MuiFab-root {

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -1005,7 +1005,7 @@ const handleInputChange = (
         open={speedDialOpen}
         onOpen={() => setSpeedDialOpen(true)}
         onClose={() => setSpeedDialOpen(false)}
-        sx={{ position: 'fixed', top: speedDialPos.y, left: speedDialPos.x, zIndex: 1500 }}
+        sx={{ position: 'fixed', top: speedDialPos.y, left: speedDialPos.x, zIndex: 9999 }}
         className="fab"
         onPointerDown={(e) => {
           if ((e.target as HTMLElement).closest('.MuiSpeedDial-fab')) {

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -495,7 +495,7 @@ const ChatInboxPage: React.FC = () => {
         open={speedDialOpen}
         onOpen={() => setSpeedDialOpen(true)}
         onClose={() => setSpeedDialOpen(false)}
-        sx={{ position: 'fixed', top: speedDialPos.y, left: speedDialPos.x, zIndex: 1500 }}
+        sx={{ position: 'fixed', top: speedDialPos.y, left: speedDialPos.x, zIndex: 9999 }}
 
         className="fab"
         onPointerDown={(e) => {


### PR DESCRIPTION
## Summary
- update `.fab` class and inline props so that speed dials appear above all elements

## Testing
- `npm install`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684616d520dc8332a48dc167a517b6ad