### PR TITLE
Fix SpeedDial clipping in TabPanel

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -509,7 +509,13 @@ body.tg-dark .conversation-nav .MuiPaginationItem-root {
 .tab-panel {
   flex: 1;
   display: flex;
-  overflow: hidden;
+  /* allow children like SpeedDial to extend outside */
+  overflow: visible;
+}
+
+/* keep SpeedDial from shrinking when used inside flex containers */
+.MuiSpeedDial-root {
+  flex: 0 0 auto;
 }
 
 .tab-panel[hidden] {


### PR DESCRIPTION
## Summary
- prevent TabPanel from clipping absolutely positioned children like SpeedDial
- keep SpeedDial flex item from shrinking

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684684df011883328332809d93e5b7d0