### PR TITLE
Fix SpeedDial off-screen positioning

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -509,8 +509,8 @@ body.tg-dark .conversation-nav .MuiPaginationItem-root {
 .tab-panel {
   flex: 1;
   display: flex;
-  /* allow children like SpeedDial to extend outside */
-  overflow: visible;
+  overflow-y: scroll;
+  overflow-x: hidden;
 }
 
 /* keep SpeedDial from shrinking when used inside flex containers */


### PR DESCRIPTION
## Summary
- measure SpeedDial size with a ref
- clamp position using viewport and dial dimensions
- keep dial within bounds on mount and on resize
- make TabPanel scrollable so chat lists can overflow

## Testing
- `npm test --silent -- -w 0`


------
https://chatgpt.com/codex/tasks/task_e_6846a82b2d948332bf66d709c48baf1e