### PR TITLE
Fix dark mode timer icon color

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -135,6 +135,7 @@
   border: none;
   cursor: pointer;
   font-size: 16px;
+  color: var(--tg-text-color);
 }
 
 


### PR DESCRIPTION
## Summary
- ensure delay button uses text color variable so icon turns white in dark mode

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684742803ba08332bcb777345aeacdb5