### PR TITLE
Integrate Telegram login

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,37 @@
+export const BASE_URL = 'https://prop-backend-worker.elmtalabx.workers.dev';
+
+export async function startLogin(telegramId: string, phone: string): Promise<string> {
+  const resp = await fetch(`${BASE_URL}/api/avatars/start`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ telegramId, phone }),
+  });
+  if (!resp.ok) throw new Error('Failed to start login');
+  const data = await resp.json();
+  return data.loginId as string;
+}
+
+export async function verifyLogin(loginId: string, code: string): Promise<string> {
+  const resp = await fetch(`${BASE_URL}/api/avatars/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ loginId, code }),
+  });
+  if (!resp.ok) throw new Error('Failed to verify login');
+  const data = await resp.json();
+  return data.avatarId as string;
+}
+
+export async function listAvatars(telegramId: string): Promise<string[]> {
+  const resp = await fetch(`${BASE_URL}/api/avatars?telegramId=${encodeURIComponent(telegramId)}`);
+  if (!resp.ok) throw new Error('Failed to list avatars');
+  const data = await resp.json();
+  return data.avatarIds as string[];
+}
+
+export async function getAvatar(avatarId: string): Promise<{ telegramId: string; sessionString: string }> {
+  const resp = await fetch(`${BASE_URL}/api/avatar?avatarId=${encodeURIComponent(avatarId)}`);
+  if (!resp.ok) throw new Error('Failed to get avatar');
+  const data = await resp.json();
+  return data as { telegramId: string; sessionString: string };
+}

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -33,23 +33,14 @@ import DoneIcon from '@mui/icons-material/Done';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
 
 import { Link, useParams } from 'react-router-dom';
+import { listAvatars, getAvatar } from '../api';
 
 interface Avatar {
   id: string;
-  avatar: string;
-  color: string;
+  telegramId: string;
+  avatar?: string;
+  color?: string;
 }
-
-const avatars: Avatar[] = [
-  { id: 'kursat', avatar: 'https://avatars.githubusercontent.com/u/80540635?v=4', color: '#ffadad' },
-  { id: 'emre', avatar: 'https://avatars.githubusercontent.com/u/41473129?v=4', color: '#ffd6a5' },
-  { id: 'abdurrahim', avatar: 'https://avatars.githubusercontent.com/u/90318672?v=4', color: '#fdffb6' },
-  { id: 'esra', avatar: 'https://avatars.githubusercontent.com/u/53093667?s=100&v=4', color: '#caffbf' },
-  { id: 'bensu', avatar: 'https://avatars.githubusercontent.com/u/50342489?s=100&v=4', color: '#9bf6ff' },
-  { id: 'burhan', avatar: 'https://avatars.githubusercontent.com/u/80754124?s=100&v=4', color: '#a0c4ff' },
-  { id: 'abdurrahman', avatar: 'https://avatars.githubusercontent.com/u/15075759?s=100&v=4', color: '#bdb2ff' },
-  { id: 'ahmet', avatar: 'https://avatars.githubusercontent.com/u/57258793?s=100&v=4', color: '#ffc6ff' },
-];
 
 interface Message {
   id: number;
@@ -69,17 +60,6 @@ interface Conversation {
   messages: Message[];
 }
 
-const initialMessages: Record<string, Message[]> = {
-  kursat: [{ id: 1, uuid: uuidv4(), from: 'kursat', text: "Why don't we go to the mall this weekend ?", delay: 0, status: 'draft' }],
-  emre: [{ id: 1, uuid: uuidv4(), from: 'emre', text: 'Send me our photos.', delay: 0, status: 'draft' }],
-  abdurrahim: [{ id: 1, uuid: uuidv4(), from: 'abdurrahim', text: 'Hey ! Send me the animation video please.', delay: 0, status: 'draft' }],
-  esra: [{ id: 1, uuid: uuidv4(), from: 'esra', text: 'I need a random voice.', delay: 0, status: 'draft' }],
-  bensu: [{ id: 1, uuid: uuidv4(), from: 'bensu', text: 'Send your location.', delay: 0, status: 'draft' }],
-  burhan: [{ id: 1, uuid: uuidv4(), from: 'burhan', text: 'Recommend me some songs.', delay: 0, status: 'draft' }],
-  abdurrahman: [{ id: 1, uuid: uuidv4(), from: 'abdurrahman', text: 'Where is the presentation file ?', delay: 0, status: 'draft' }],
-  ahmet: [{ id: 1, uuid: uuidv4(), from: 'ahmet', text: "Let's join the daily meeting.", delay: 0, status: 'draft' }],
-};
-
 
 const ChatConversationPage: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -89,7 +69,7 @@ const ChatConversationPage: React.FC = () => {
     {
       id: uuidv4(),
       startDateTime: initialStart,
-      messages: initialMessages[id ?? ''] || [],
+      messages: [],
     },
   ]);
   const [conversationIndex, setConversationIndex] = useState(0);
@@ -97,7 +77,8 @@ const ChatConversationPage: React.FC = () => {
 
 
   const [text, setText] = useState('');
-  const [selectedAvatar, setSelectedAvatar] = useState<Avatar>(avatars[0]);
+  const [avatars, setAvatars] = useState<Avatar[]>([]);
+  const [selectedAvatar, setSelectedAvatar] = useState<Avatar | null>(null);
   const [showAvatars, setShowAvatars] = useState(false);
   const [replyTo, setReplyTo] = useState<Message | null>(null);
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -112,6 +93,42 @@ const ChatConversationPage: React.FC = () => {
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const messagesRef = useRef<HTMLDivElement>(null);
   const [groupInfo, setGroupInfo] = useState<any>(null);
+
+  useEffect(() => {
+    let tgId: string | null = null;
+    const stored = localStorage.getItem('tg_init_data');
+    if (stored) {
+      try {
+        tgId = String(JSON.parse(stored).user?.id ?? '');
+      } catch {
+        /* ignore */
+      }
+    }
+    if (!tgId) {
+      const tg = (window as any).Telegram?.WebApp;
+      tgId = tg?.initDataUnsafe?.user?.id ? String(tg.initDataUnsafe.user.id) : null;
+    }
+    if (!tgId) return;
+    listAvatars(tgId)
+      .then(async (ids) => {
+        const avs: Avatar[] = [];
+        for (const aid of ids) {
+          try {
+            const data = await getAvatar(aid);
+            avs.push({ id: aid, telegramId: data.telegramId });
+          } catch {
+            /* ignore */
+          }
+        }
+        setAvatars(avs);
+        if (avs.length && !selectedAvatar) {
+          setSelectedAvatar(avs[0]);
+        }
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
 
   useEffect(() => {
     const stored = localStorage.getItem('conversations');
@@ -132,7 +149,7 @@ const ChatConversationPage: React.FC = () => {
             return {
               id: idx + 1,
               uuid: m.message_id || m.uuid || uuidv4(),
-              from: m.sender_id || m.from || avatars[0].id,
+              from: m.sender_id || m.from || '',
               text: m.text || m.message_content || '',
               delay: 0,
               status: m.status || defaultStatus,
@@ -219,7 +236,7 @@ const ChatConversationPage: React.FC = () => {
         return {
           conversation_id: conv.id,
           start_time: conv.startDateTime.toISOString(),
-          initiated_by: conv.messages[0]?.from || selectedAvatar.id,
+          initiated_by: conv.messages[0]?.from || selectedAvatar?.id || '',
           topic: '',
           conversation_metadata: { active: true, tags: [] },
           messages: msgs,
@@ -357,6 +374,7 @@ const ChatConversationPage: React.FC = () => {
 
 const handleSend = () => {
   if (!text.trim()) return;
+  if (!selectedAvatar) return;
   updateMessages((prev) => {
     if (editingId !== null) {
       return prev.map((m) => (m.id === editingId ? { ...m, text } : m));
@@ -367,7 +385,7 @@ const handleSend = () => {
       {
         id: newId,
         uuid: uuidv4(),
-        from: selectedAvatar.id,
+        from: selectedAvatar?.id || '',
         text,
         delay: 0,
         status: 'draft',
@@ -397,7 +415,7 @@ const handleSend = () => {
     setInputFocused(false);
   };
 
-  const getAvatar = (id: string) => avatars.find((a) => a.id === id) || avatars[0];
+  const getAvatar = (id: string) => avatars.find((a) => a.id === id) || { id: '', telegramId: '' };
 
   const handleSwipeReply = (msg: Message) => {
     setMenuId(null);
@@ -464,11 +482,11 @@ const handleSend = () => {
   const handleGenerateBotMessages = () => {
     updateMessages((prev) => {
       let nextId = prev.length ? prev[prev.length - 1].id : 0;
-      const others = avatars.filter((a) => a.id !== selectedAvatar.id);
+      const others = avatars.filter((a) => a.id !== selectedAvatar?.id);
       const count = others.length;
       const generated: Message[] = [];
       for (let i = 0; i < 10; i++) {
-        const from = others[i % count].id;
+        const from = count ? others[i % count].id : selectedAvatar?.id || '';
         generated.push({
           id: ++nextId,
           uuid: uuidv4(),
@@ -685,7 +703,7 @@ const handleInputChange = (
       >
         {messages.map((msg, idx) => {
           const av = getAvatar(msg.from);
-          const me = msg.from === selectedAvatar.id;
+          const me = msg.from === selectedAvatar?.id;
           const reply = msg.replyTo != null ? messages.find((m) => m.id === msg.replyTo) : null;
           return (
             <React.Fragment key={msg.id}>
@@ -904,7 +922,7 @@ const handleInputChange = (
       <div className={`message-input-container ${inputFocused ? 'focused' : ''}`}>
         <div style={{ position: 'relative' }}>
           <img
-            src={selectedAvatar.avatar}
+            src={selectedAvatar?.avatar || 'https://placehold.co/28x28'}
             className="selected-avatar"
             alt="selected avatar"
             onClick={() => setShowAvatars((s) => !s)}
@@ -914,8 +932,8 @@ const handleInputChange = (
               {avatars.map((a) => (
                 <img
                   key={a.id}
-                  src={a.avatar}
-                  alt={a.id}
+                  src={a.avatar || 'https://placehold.co/28x28'}
+                  alt={a.telegramId}
                   onClick={() => {
                     setSelectedAvatar(a);
                     setShowAvatars(false);

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -31,6 +31,7 @@ import FormControlLabel from '@mui/material/FormControlLabel';
 import Chip from '@mui/material/Chip';
 import AddIcon from '@mui/icons-material/Add';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { startLogin, verifyLogin, listAvatars } from '../api';
 
 
 interface TabPanelProps {
@@ -323,10 +324,12 @@ const ChatInboxPage: React.FC = () => {
   const [traitInput, setTraitInput] = useState('');
 
   const [addUserOpen, setAddUserOpen] = useState(false);
+  const [countryCode, setCountryCode] = useState('+1');
   const [phoneNumber, setPhoneNumber] = useState('');
   const [codeSent, setCodeSent] = useState(false);
   const [verificationCode, setVerificationCode] = useState('');
   const [addingUser, setAddingUser] = useState(false);
+  const [loginId, setLoginId] = useState('');
 
   const handleToggleGroup = (group: string) => {
     setSelectedGroups((prev) =>
@@ -358,48 +361,72 @@ const ChatInboxPage: React.FC = () => {
     }));
   };
 
-  const handleSendPhone = () => {
-    const phone = phoneNumber.trim();
+  const handleSendPhone = async () => {
+    const phone = `${countryCode}${phoneNumber.trim()}`;
     if (!phone) return;
-    setAddingUser(true);
-    fetch(
-      'https://prop-backend-worker.elmtalabx.workers.dev/api/telegram/send-code',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone }),
-      }
-    )
-      .then(() => setCodeSent(true))
-      .catch(() => {
+    let tgId: string | null = null;
+    const tgStr = localStorage.getItem('tg_init_data');
+    if (tgStr) {
+      try {
+        tgId = String(JSON.parse(tgStr).user?.id ?? '');
+      } catch {
         /* ignore */
-      })
-      .finally(() => setAddingUser(false));
+      }
+    }
+    if (!tgId) {
+      const tg = (window as any).Telegram?.WebApp;
+      tgId = tg?.initDataUnsafe?.user?.id ? String(tg.initDataUnsafe.user.id) : null;
+    }
+    if (!tgId) return;
+    setAddingUser(true);
+    try {
+      const id = await startLogin(tgId, phone);
+      setLoginId(id);
+      setCodeSent(true);
+    } catch {
+      /* ignore */
+    } finally {
+      setAddingUser(false);
+    }
   };
 
-  const handleVerifyCode = () => {
+  const handleVerifyCode = async () => {
     const code = verificationCode.trim();
-    if (!code) return;
-    setAddingUser(true);
-    fetch(
-      'https://prop-backend-worker.elmtalabx.workers.dev/api/telegram/verify-code',
-      {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone: phoneNumber.trim(), code }),
-      }
-    )
-      .then(() => {
-        setAddUserOpen(false);
-        setCodeSent(false);
-        setPhoneNumber('');
-        setVerificationCode('');
-        alert('User logged in');
-      })
-      .catch(() => {
+    if (!code || !loginId) return;
+    let tgId: string | null = null;
+    const tgStr = localStorage.getItem('tg_init_data');
+    if (tgStr) {
+      try {
+        tgId = String(JSON.parse(tgStr).user?.id ?? '');
+      } catch {
         /* ignore */
-      })
-      .finally(() => setAddingUser(false));
+      }
+    }
+    if (!tgId) {
+      const tg = (window as any).Telegram?.WebApp;
+      tgId = tg?.initDataUnsafe?.user?.id ? String(tg.initDataUnsafe.user.id) : null;
+    }
+    if (!tgId) return;
+    setAddingUser(true);
+    try {
+      await verifyLogin(loginId, code);
+      const list = await listAvatars(tgId);
+      try {
+        localStorage.setItem('avatarIds', JSON.stringify(list));
+      } catch {
+        /* ignore */
+      }
+      setAddUserOpen(false);
+      setCodeSent(false);
+      setPhoneNumber('');
+      setVerificationCode('');
+      setLoginId('');
+      alert('User logged in');
+    } catch {
+      /* ignore */
+    } finally {
+      setAddingUser(false);
+    }
   };
 
   const handleSearchGroup = () => {
@@ -723,12 +750,20 @@ const ChatInboxPage: React.FC = () => {
         <DialogTitle>Add Telegram User</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           {!codeSent ? (
-            <TextField
-              label="Phone Number"
-              value={phoneNumber}
-              onChange={(e) => setPhoneNumber(e.target.value)}
-              fullWidth
-            />
+            <>
+              <TextField
+                label="Country Code"
+                value={countryCode}
+                onChange={(e) => setCountryCode(e.target.value)}
+                fullWidth
+              />
+              <TextField
+                label="Phone Number"
+                value={phoneNumber}
+                onChange={(e) => setPhoneNumber(e.target.value)}
+                fullWidth
+              />
+            </>
           ) : (
             <TextField
               label="2FA Code"


### PR DESCRIPTION
## Summary
- implement API wrappers for Telegram avatar login
- update Add User flow to request country code and use new login API
- load user avatars in chat conversation page and use avatar IDs as sender IDs

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6848c20a147c8332a562fe15e7b89b4c