### PR TITLE
Handle Telegram password during avatar login

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -11,13 +11,28 @@ export async function startLogin(telegramId: string, phone: string): Promise<str
   return data.loginId as string;
 }
 
-export async function verifyLogin(loginId: string, code: string): Promise<string> {
+export async function verifyLogin(
+  loginId: string,
+  code: string,
+  password?: string,
+): Promise<string> {
+  const payload: any = { loginId, code };
+  if (password) payload.password = password;
+
   const resp = await fetch(`${BASE_URL}/api/avatars/verify`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ loginId, code }),
+    body: JSON.stringify(payload),
   });
-  if (!resp.ok) throw new Error('Failed to verify login');
+
+  if (!resp.ok) {
+    try {
+      const err = await resp.json();
+      throw new Error(err.error || 'Failed to verify login');
+    } catch {
+      throw new Error('Failed to verify login');
+    }
+  }
   const data = await resp.json();
   return data.avatarId as string;
 }

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -330,6 +330,8 @@ const ChatInboxPage: React.FC = () => {
   const [phoneNumber, setPhoneNumber] = useState('');
   const [codeSent, setCodeSent] = useState(false);
   const [verificationCode, setVerificationCode] = useState('');
+  const [needPassword, setNeedPassword] = useState(false);
+  const [telegramPassword, setTelegramPassword] = useState('');
   const [addingUser, setAddingUser] = useState(false);
   const [loginId, setLoginId] = useState('');
 
@@ -418,13 +420,20 @@ const ChatInboxPage: React.FC = () => {
     setAddingUser(true);
     try {
       await toast.promise(
-        verifyLogin(loginId, code),
+        verifyLogin(
+          loginId,
+          code,
+          needPassword ? telegramPassword.trim() || undefined : undefined,
+        ),
         {
           loading: 'Verifying...',
           success: 'User logged in',
-          error: 'Verification failed',
-        }
+          error: (err) => err.message || 'Verification failed',
+        },
       );
+
+      setNeedPassword(false);
+      setTelegramPassword('');
 
       const list = await listAvatars(tgId);
       try {
@@ -432,15 +441,26 @@ const ChatInboxPage: React.FC = () => {
       } catch {
         /* ignore */
       }
-      setAddUserOpen(false);
-      setCodeSent(false);
-      setPhoneNumber('');
-      setVerificationCode('');
-      setLoginId('');
+      handleCloseAddUser();
 
+    } catch (err: any) {
+      if (err.message === 'password required') {
+        setNeedPassword(true);
+        return;
+      }
     } finally {
       setAddingUser(false);
     }
+  };
+
+  const handleCloseAddUser = () => {
+    setAddUserOpen(false);
+    setCodeSent(false);
+    setNeedPassword(false);
+    setTelegramPassword('');
+    setPhoneNumber('');
+    setVerificationCode('');
+    setLoginId('');
   };
 
   const handleSearchGroup = () => {
@@ -760,7 +780,7 @@ const ChatInboxPage: React.FC = () => {
         </DialogActions>
       </Dialog>
 
-      <Dialog open={addUserOpen} onClose={() => setAddUserOpen(false)} fullWidth>
+      <Dialog open={addUserOpen} onClose={handleCloseAddUser} fullWidth>
         <DialogTitle>Add Telegram User</DialogTitle>
         <DialogContent sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
           {!codeSent ? (
@@ -779,12 +799,23 @@ const ChatInboxPage: React.FC = () => {
               />
             </>
           ) : (
-            <TextField
-              label="2FA Code"
-              value={verificationCode}
-              onChange={(e) => setVerificationCode(e.target.value)}
-              fullWidth
-            />
+            <>
+              <TextField
+                label="2FA Code"
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value)}
+                fullWidth
+              />
+              {needPassword && (
+                <TextField
+                  label="Password"
+                  type="password"
+                  value={telegramPassword}
+                  onChange={(e) => setTelegramPassword(e.target.value)}
+                  fullWidth
+                />
+              )}
+            </>
           )}
         </DialogContent>
         <DialogActions>
@@ -797,7 +828,7 @@ const ChatInboxPage: React.FC = () => {
               {addingUser ? <CircularProgress size={20} /> : 'Verify'}
             </Button>
           )}
-          <Button onClick={() => setAddUserOpen(false)}>Close</Button>
+          <Button onClick={handleCloseAddUser}>Close</Button>
         </DialogActions>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- allow verify login API to accept optional password and return error messages
- support Telegram accounts with 2FA in the inbox page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68495ee4c7008332841050df51ddca2d