### PR TITLE
Add loading overlays

### DIFF
--- a/src/LoadingOverlay.tsx
+++ b/src/LoadingOverlay.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import Backdrop from '@mui/material/Backdrop';
+import CircularProgress from '@mui/material/CircularProgress';
+
+interface LoadingOverlayProps {
+  open: boolean;
+}
+
+const LoadingOverlay: React.FC<LoadingOverlayProps> = ({ open }) => (
+  <Backdrop
+    open={open}
+    sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}
+  >
+    <CircularProgress color="inherit" />
+  </Backdrop>
+);
+
+export default LoadingOverlay;

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -31,6 +31,7 @@ import AddIcon from '@mui/icons-material/Add';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import DoneIcon from '@mui/icons-material/Done';
 import DoneAllIcon from '@mui/icons-material/DoneAll';
+import LoadingOverlay from '../LoadingOverlay';
 
 import { Link, useParams } from 'react-router-dom';
 import { listAvatars, getAvatar } from '../api';
@@ -595,7 +596,9 @@ const handleInputChange = (
   })();
 
   return (
-    <div
+    <>
+      <LoadingOverlay open={generating} />
+      <div
       className="chat-container"
       style={{
         paddingBottom: 80,
@@ -1028,6 +1031,7 @@ const handleInputChange = (
 
 
     </div>
+    </>
   );
 };
 

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -33,6 +33,7 @@ import AddIcon from '@mui/icons-material/Add';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { startLogin, verifyLogin, listAvatars } from '../api';
 import { toast } from 'react-hot-toast';
+import LoadingOverlay from '../LoadingOverlay';
 
 
 
@@ -563,6 +564,7 @@ const ChatInboxPage: React.FC = () => {
 
   return (
     <>
+      <LoadingOverlay open={searching || addingUser} />
       <div className="chat-container" style={{ height: viewportHeight }}>
       <div className="inbox-header">
         <h2>Chats</h2>


### PR DESCRIPTION
## Summary
- show a global loading overlay component
- display the overlay during inbox actions
- display the overlay while scheduling messages

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68498d73e9bc833291b91302a2c763db