### PR TITLE
Add group avatar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,30 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Backend API
+
+### `GET /api/group-cover`
+
+Retrieves and caches a Telegram group's profile image. This route expects a
+`groupId` query parameter and returns the image in JPEG format. If the image is
+not already cached it is fetched from Telegram and stored for future requests.
+
+Sample request using the public worker:
+
+```http
+GET https://prop-backend-worker.elmtalabx.workers.dev/api/group-cover?groupId=123456
+```
+
+Sample successful response:
+
+```
+HTTP/1.1 200 OK
+Content-Type: image/jpeg
+ETag: "<etag-from-R2>"
+
+(binary JPEG data)
+```
+
+Possible error responses include `400` when `groupId` is missing and `404` when
+the group has no profile image.

--- a/src/GroupAvatar.tsx
+++ b/src/GroupAvatar.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { getGroupCoverUrl } from './api';
+
+interface GroupAvatarProps {
+  groupId: string | number;
+  className?: string;
+  alt?: string;
+}
+
+const GroupAvatar: React.FC<GroupAvatarProps> = ({ groupId, className, alt }) => {
+  const url = getGroupCoverUrl(String(groupId));
+  return <img src={url} className={className} alt={alt ?? String(groupId)} />;
+};
+
+export default GroupAvatar;

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -34,7 +34,8 @@ import DoneAllIcon from '@mui/icons-material/DoneAll';
 import LoadingOverlay from '../LoadingOverlay';
 
 import { Link, useParams } from 'react-router-dom';
-import { listAvatars, getAvatar, getGroupCoverUrl } from '../api';
+import { listAvatars, getAvatar } from '../api';
+import GroupAvatar from '../GroupAvatar';
 
 interface Avatar {
   id: string;
@@ -622,8 +623,8 @@ const handleInputChange = (
     >
       <div className="chat-header">
         <Link to="/chat" className="back-icon">←</Link>
-        <img
-          src={getGroupCoverUrl(String(id))}
+        <GroupAvatar
+          groupId={id ?? ''}
           className="header-avatar"
           alt={id}
         />


### PR DESCRIPTION
## Summary
- document the `GET /api/group-cover` endpoint with request and response examples in README
- add `GroupAvatar` component for fetching a group's cover image
- use `GroupAvatar` in the chat conversation page header

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bf5faac08332be35a9e7b1912735