### PR TITLE
Update group cover URL logic

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -624,7 +624,15 @@ const handleInputChange = (
       <div className="chat-header">
         <Link to="/chat" className="back-icon">←</Link>
         <GroupAvatar
-          groupId={id ?? ''}
+          groupId={
+            groupInfo?.username
+              ? `${
+                  groupInfo.username.startsWith('@')
+                    ? groupInfo.username
+                    : '@' + groupInfo.username
+                }`
+              : String(id ?? '')
+          }
           className="header-avatar"
           alt={id}
         />

--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -269,7 +269,11 @@ const ChatInboxPage: React.FC = () => {
 
     return {
       id,
-      avatar: getGroupCoverUrl(String(id)),
+      avatar: getGroupCoverUrl(
+        g.username
+          ? `${g.username.startsWith('@') ? g.username : '@' + g.username}`
+          : String(id)
+      ),
 
       alt: name,
       title: name,


### PR DESCRIPTION
## Summary
- ensure `ChatConversationPage` uses group username when available for cover
- use group usernames in chat list avatar URLs

## Testing
- `npm test --silent --forceExit` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849c8632a0083328e020aeef055460e