### PR TITLE
Update schedule button UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -382,13 +382,6 @@ body.tg-dark .conversation-nav .MuiPaginationItem-root {
   box-shadow: 0 0 6px rgba(0, 198, 255, 0.6);
 }
 
-.schedule-btn {
-  padding: 6px 12px;
-  font-size: 14px;
-  border-radius: 8px;
-  width: auto;
-}
-
 .inbox-header {
   display: flex;
   justify-content: space-between;

--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -996,21 +996,20 @@ const handleInputChange = (
           <SmartToyIcon />
         </IconButton>
 
-        <Button
-          className="generate-btn schedule-btn"
+        <IconButton
+          onMouseDown={(e) => e.preventDefault()}
           onClick={handleSchedule}
+          color="primary"
+          aria-label="schedule"
           disabled={generating}
           style={{ marginLeft: 4 }}
         >
           {generating ? (
             <CircularProgress size={20} color="inherit" />
           ) : (
-            <>
-              <AutoAwesomeIcon style={{ marginRight: 4 }} />
-              Schedule
-            </>
+            <AutoAwesomeIcon />
           )}
-        </Button>
+        </IconButton>
 
         <IconButton
           className="send-button"


### PR DESCRIPTION
## Summary
- change schedule button on chat page to icon for a smaller footprint
- remove unused schedule button CSS

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6849d795158c8332ba0632f1d28cd015