### PR TITLE
Enable group list tab via query

### DIFF
--- a/src/pages/ChatInboxPage.tsx
+++ b/src/pages/ChatInboxPage.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useLayoutEffect, useRef } from 'react';
 
 import { createPortal } from 'react-dom';
 
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 
 import { ChatList } from 'react-chat-elements';
 import 'react-chat-elements/dist/main.css';
@@ -143,8 +143,11 @@ const mergeGroups = (remote: any[] = [], local: any[] = []) => {
 
 const ChatInboxPage: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
+  const searchParams = new URLSearchParams(location.search);
+  const initialTab = Number(searchParams.get('tab') ?? '0');
   const [groups, setGroups] = useState<any[]>([]);
-  const [tabIndex, setTabIndex] = useState(0);
+  const [tabIndex, setTabIndex] = useState(initialTab);
   const [userGroups, setUserGroups] = useState<any[]>([]);
 
   useEffect(() => {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -88,7 +88,7 @@ const HomePage: React.FC = () => {
             {JSON.stringify(initData, null, 2)}
           </pre>
         )}
-        <button onClick={() => navigate('/chat')}>Go to Chat</button>
+        <button onClick={() => navigate('/chat?tab=3')}>Go to Chat</button>
       </header>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep group inbox active when navigating to chat from home
- parse the `tab` query parameter in `ChatInboxPage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a102783388332b6ae90ac65a71699