### PR TITLE
Adjust DateTimePicker input handling

### DIFF
--- a/src/pages/ChatConversationPage.tsx
+++ b/src/pages/ChatConversationPage.tsx
@@ -661,8 +661,15 @@ const handleInputChange = (
       '.header-datetime input'
     ) as NodeListOf<HTMLInputElement>;
     inputs.forEach((input) => {
-      input.readOnly = true;
-      input.setAttribute('inputmode', 'none');
+      if ((input as HTMLInputElement).hidden) return;
+      const name = input.getAttribute('name');
+      if (name === 'day' || name === 'month' || name === 'year') {
+        input.readOnly = true;
+        input.setAttribute('inputmode', 'none');
+      } else {
+        input.readOnly = false;
+        input.removeAttribute('inputmode');
+      }
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- adjust `DateTimePicker` logic to keep keyboard hidden only for date inputs

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df0417b748332aebfba02ac4a10d2